### PR TITLE
feat: Add CUGA and sport logos to main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,6 @@
                         Ce sport développe l'apnée, la force physique, l'agilité sous l'eau et la coordination d'équipe. Il est parfait pour ceux qui aiment les défis aquatiques et la collaboration.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Des clubs existent à travers le Canada.</p>
-                    <a href="#entrainement-hockey" class="mt-6 inline-block bg-blue-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-blue-800 transition duration-300 shadow-lg">Voir l'entraînement d'initiation</a>
                 </div>
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="200">
@@ -139,7 +138,6 @@
                         Ce sport développe l'apnée, la puissance, la tactique spatiale et la capacité à travailler en équipe dans un environnement unique. Il est idéal pour les athlètes cherchant un sport aquatique intense et stratégique.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Des clubs existent à travers le Canada.</p>
-                    <a href="#entrainement-rugby" class="mt-6 inline-block bg-green-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-green-800 transition duration-300 shadow-lg">Voir l'entraînement d'initiation</a>
                 </div>
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="300">
@@ -168,43 +166,12 @@
             </a>
         </section>
 
-        <section id="entrainement" class="bg-gray-200 px-4 py-16" data-aos="fade-up">
-            <div class="container mx-auto">
-                <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">Entraînements d'Initiation Simples</h2>
-
-                <div id="entrainement-hockey" class="bg-white rounded-xl shadow-lg p-8 mb-10" data-aos="fade-up" data-aos-delay="100">
-                    <h3 class="text-2xl font-bold mb-4 text-blue-800">Initiation au Hockey Subaquatique</h3>
-                    <p class="text-gray-700 leading-relaxed mb-6">
-                        Découvrez les mouvements de base et la manipulation du palet sous l'eau.
-                    </p>
-                    <ul class="list-disc list-inside text-gray-700 space-y-2">
-                        <li>Échauffement dans l'eau (nage douce, battements de jambes).</li>
-                        <li>Exercices d'apnée statique et dynamique (courtes distances).</li>
-                        <li>Familiarisation avec l'équipement (palmes, masque, tuba, crosse, palet).</li>
-                        <li>Drills de poussée du palet au fond de la piscine.</li>
-                        <li>Drills simples de passes entre partenaires.</li>
-                        <li>Petits matchs simulés pour appliquer les bases.</li>
-                    </ul>
-                    <img src="images/hockey-drill.jpg" alt="Illustration d'exercice Hockey Subaquatique" class="rounded-md mt-8 w-full h-auto object-cover">
-                </div>
-
-                <div id="entrainement-rugby" class="bg-white rounded-xl shadow-lg p-8" data-aos="fade-up" data-aos-delay="200">
-                    <h3 class="text-2xl font-bold mb-4 text-green-800">Initiation au Rugby Subaquatique</h3>
-                    <p class="text-gray-700 leading-relaxed mb-6">
-                        Apprenez à vous déplacer en 3D et à interagir avec le ballon et les adversaires.
-                    </p>
-                    <ul class="list-disc list-inside text-gray-700 space-y-2">
-                        <li>Échauffement et nage en profondeur.</li>
-                        <li>Exercices d'apnée en mouvement et de descente rapide.</li>
-                        <li>Familiarisation avec le ballon et les paniers.</li>
-                        <li>Drills de passes et de réception du ballon sous l'eau.</li>
-                        <li>Exercices de positionnement et de déplacement en 3D.</li>
-                        <li>Introduction aux règles de contact et simulations de jeu.</li>
-                    </ul>
-                    <img src="images/rugby-drill.jpg" alt="Illustration d'exercice Rugby Subaquatique" class="rounded-md mt-8 w-full h-auto object-cover">
-                </div>
-
-            </div>
+        <section class="container mx-auto px-4 py-16 text-center" data-aos="fade-up">
+            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">Championnats Canadiens de Hockey Subaquatique 2025</h2>
+            <img src="competitions/2025-Canadian-Underwater-Hockey-Nationals.jpeg" alt="Affiche des Championnats Canadiens de Hockey Subaquatique 2025" class="rounded-lg mb-6 mx-auto shadow-xl w-full md:w-2/3 lg:w-1/2">
+            <p class="text-xl text-gray-700 mb-2"><strong>Date :</strong> Vendredi 13 juin 2025 - Dimanche 15 juin 2025</p>
+            <p class="text-xl text-gray-700 mb-2"><strong>Lieu :</strong> Centre Sportif de Gatineau, 850 Bd de la Gappe, Gatineau, QC J8T 7T7</p>
+            <p class="text-lg text-gray-700 mt-4 leading-relaxed">CUGA est ravi d'organiser les Championnats Canadiens de Hockey Subaquatique 2025 à Gatineau! Venez encourager les meilleures équipes du pays.</p>
         </section>
 
          <section id="contact" class="bg-gray-800 text-white px-4 py-16">
@@ -231,13 +198,6 @@
         <footer class="bg-gray-900 text-gray-400 py-8 text-center">
             <div class="container mx-auto px-4">
                 <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                    <span>
-                        <i class="fa fa-flag-quebec text-blue-200 mr-1"></i>
-                        <a href="https://quebecsubaquatique.ca/hockey-subaquatique/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                            Hockey subaquatique Québec
-                        </a>
-                    </span>
-                    <span class="mx-2">|</span>
                     <span>
                         <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
                         <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
@@ -293,7 +253,6 @@
                         This sport develops breath-holding, physical strength, underwater agility, and team coordination. It's perfect for those who enjoy aquatic challenges and collaboration.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Clubs exist across Canada.</p>
-                    <a href="#entrainement-hockey-en" class="mt-6 inline-block bg-blue-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-blue-800 transition duration-300 shadow-lg">See introductory training</a>
                 </div>
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="200">
@@ -307,7 +266,6 @@
                         This sport develops breath-holding, power, spatial tactics, and the ability to work as a team in a unique environment. It's ideal for athletes seeking an intense and strategic aquatic sport.
                     </p>
                     <p class="text-lg font-semibold text-gray-900 mt-4">Clubs exist across Canada.</p>
-                     <a href="#entrainement-rugby-en" class="mt-6 inline-block bg-green-700 text-white px-8 py-3 rounded-full font-semibold hover:bg-green-800 transition duration-300 shadow-lg">See introductory training</a>
                 </div>
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="300">
@@ -336,43 +294,12 @@
             </a>
         </section>
 
-        <section id="entrainement-en" class="bg-gray-200 px-4 py-16" data-aos="fade-up">
-            <div class="container mx-auto">
-                <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">Simple Introductory Trainings</h2>
-
-                <div id="entrainement-hockey-en" class="bg-white rounded-xl shadow-lg p-8 mb-10" data-aos="fade-up" data-aos-delay="100">
-                    <h3 class="text-2xl font-bold mb-4 text-blue-800">Introduction to Underwater Hockey</h3>
-                    <p class="text-gray-700 leading-relaxed mb-6">
-                        Discover the basic movements and puck handling underwater.
-                    </p>
-                    <ul class="list-disc list-inside text-gray-700 space-y-2">
-                        <li>Warm-up in the water (light swimming, butt kicks, high knees).</li>
-                        <li>Static and dynamic breath-holding exercises (short distances).</li>
-                        <li>Familiarization with equipment (fins, mask, snorkel, stick, puck).</li>
-                        <li>Puck pushing drills on the pool bottom.</li>
-                        <li>Simple passing drills with partners.</li>
-                        <li>Small simulated games to apply the basics.</li>
-                    </ul>
-                    <img src="images/hockey-drill.jpg" alt="Illustration of Underwater Hockey drill" class="rounded-md mt-8 w-full h-auto object-cover">
-                </div>
-
-                <div id="entrainement-rugby-en" class="bg-white rounded-xl shadow-lg p-8" data-aos="fade-up" data-aos-delay="200">
-                    <h3 class="text-2xl font-bold mb-4 text-green-800">Introduction to Underwater Rugby</h3>
-                    <p class="text-gray-700 leading-relaxed mb-6">
-                        Learn to move in 3D and interact with the ball and opponents.
-                    </p>
-                    <ul class="list-disc list-inside text-gray-700 space-y-2">
-                        <li>Warm-up and deep water swimming.</li>
-                        <li>Moving breath-holding and rapid descent exercises.</li>
-                        <li>Familiarization with the ball and baskets.</li>
-                        <li>Passing and receiving drills underwater.</li>
-                        <li>Positioning and 3D movement exercises.</li>
-                        <li>Introduction to contact rules and game simulations.</li>
-                    </ul>
-                    <img src="images/rugby-drill.jpg" alt="Illustration of Underwater Rugby drill" class="rounded-md mt-8 w-full h-auto object-cover">
-                </div>
-
-            </div>
+        <section class="container mx-auto px-4 py-16 text-center" data-aos="fade-up">
+            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">2025 Canadian Underwater Hockey Nationals</h2>
+            <img src="competitions/2025-Canadian-Underwater-Hockey-Nationals.jpeg" alt="2025 Canadian Underwater Hockey Nationals Poster" class="rounded-lg mb-6 mx-auto shadow-xl w-full md:w-2/3 lg:w-1/2">
+            <p class="text-xl text-gray-700 mb-2"><strong>Date:</strong> Friday, June 13, 2025 - Sunday, June 15, 2025</p>
+            <p class="text-xl text-gray-700 mb-2"><strong>Location:</strong> Gatineau Sports Centre, 850 Bd de la Gappe, Gatineau, QC J8T 7T7</p>
+            <p class="text-lg text-gray-700 mt-4 leading-relaxed">CUGA is thrilled to host the 2025 Canadian Underwater Hockey Nationals in Gatineau! Come and support the best teams in the country.</p>
         </section>
 
          <section id="contact-en" class="bg-gray-800 text-white px-4 py-16">
@@ -399,13 +326,6 @@
         <footer class="bg-gray-900 text-gray-400 py-8 text-center">
             <div class="container mx-auto px-4">
                 <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                    <span>
-                        <i class="fa fa-flag-quebec text-blue-200 mr-1"></i>
-                        <a href="https://quebecsubaquatique.ca/en/hockey-subaquatique/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                            Underwater hockey Quebec
-                        </a>
-                    </span>
-                    <span class="mx-2">|</span>
                     <span>
                         <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
                         <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
 
     <div class="lang-fr">
         <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-            <img src="assets/logos/CUGA/Horizontal/FR/CUGA_Hor_FR_Bleu.svg" alt="CUGA Logo" class="h-12 mx-auto">
+            <img src="assets/logos/CUGA/Horizontal/FR/Full Color/CUGA-logo-h-fr-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto">
             <p class="mt-1 text-md md:text-lg italic">Association Canadienne des Jeux Subaquatiques</p>
             <p class="mt-1 text-md md:text-lg italic">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p>
         </header>
@@ -116,7 +116,7 @@
             <div class="flex flex-col md:flex-row gap-10">
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="100">
                     <h3 class="text-2xl font-bold mb-4 text-blue-800 flex items-center text-center">
-                        <img src="assets/logos/HOCKEY/SCREEN/FR/UWHockey_Fr_Bleu.svg" alt="Hockey Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Hockey Subaquatique
+                        <img src="assets/logos/HOCKEY/SCREEN/FR/Full Color/CUGA-WM-hockey-fr-fullColor-rgb.svg" alt="Hockey Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Hockey Subaquatique
                     </h3>
                     <img src="images/hockey.jpg" alt="Image de joueurs de Hockey Subaquatique" class="rounded-lg mb-6 w-full h-auto object-cover">
                     <p class="text-gray-700 leading-relaxed mb-6">
@@ -130,7 +130,7 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="200">
                     <h3 class="text-2xl font-bold mb-4 text-green-800 flex items-center text-center">
-                        <img src="assets/logos/RUGBY/SCREEN/FR/UWRugby_Fr_Vert.svg" alt="Rugby Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Rugby Subaquatique
+                        <img src="assets/logos/RUGBY/SCREEN/FR/Full Color/CUGA-WM-rugby-fr-fullColor-rgb.svg" alt="Rugby Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Rugby Subaquatique
                     </h3>
                     <img src="images/rugby.jpg" alt="Image de joueurs de Rugby Subaquatique" class="rounded-lg mb-6 w-full h-auto object-cover">
                     <p class="text-gray-700 leading-relaxed mb-6">
@@ -144,7 +144,7 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="300">
                     <h3 class="text-2xl font-bold mb-4 text-purple-800 flex items-center text-center">
-                        <img src="assets/logos/FOOTBALL/SCREEN/FR/UWFootball_Fr_Mauve.svg" alt="Football Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Football Subaquatique
+                        <img src="assets/logos/FOOTBALL/SCREEN/FR/Full Color/CUGA-WM-football-fr-fullColor-rgb.svg" alt="Football Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Football Subaquatique
                     </h3>
                     <!-- <img src="images/logos/uwf-logo.jpg" alt="Logo Football Subaquatique" class="w-full max-w-xs mx-auto mb-6 rounded bg-white shadow" /> -->
                     <!-- Placeholder for an action image if available in future -->
@@ -272,7 +272,7 @@
 
     <div class="lang-en">
         <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-            <img src="assets/logos/CUGA/Horizontal/EN/CUGA_Hor_EN_Blue.svg" alt="CUGA Logo" class="h-12 mx-auto">
+            <img src="assets/logos/CUGA/Horizontal/EN/Full Color/CUGA-logo-h-en-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto">
             <p class="mt-1 text-md md:text-lg italic">Canadian Underwater Games Association</p>
             <p class="mt-1 text-md md:text-lg italic">Dive into the action with Underwater Hockey and Underwater Rugby!</p>
         </header>
@@ -284,7 +284,7 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="100">
                     <h3 class="text-2xl font-bold mb-4 text-blue-800 flex items-center">
-                        <img src="assets/logos/HOCKEY/SCREEN/EN/UWHockey_En_Blue.svg" alt="Underwater Hockey Logo" class="h-10 mr-3 inline-block align-middle">Underwater Hockey
+                        <img src="assets/logos/HOCKEY/SCREEN/EN/Full Color/CUGA-WM-hockey-en-fullColor-rgb.svg" alt="Underwater Hockey Logo" class="h-10 mr-3 inline-block align-middle">Underwater Hockey
                     </h3>
                     <img src="images/hockey.jpg" alt="Image of Underwater Hockey players" class="rounded-lg mb-6 w-full h-auto object-cover">
                     <p class="text-gray-700 leading-relaxed mb-6">
@@ -298,7 +298,7 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="200">
                     <h3 class="text-2xl font-bold mb-4 text-green-800 flex items-center">
-                        <img src="assets/logos/RUGBY/SCREEN/EN/UWRugby_En_Green.svg" alt="Underwater Rugby Logo" class="h-10 mr-3 inline-block align-middle">Underwater Rugby
+                        <img src="assets/logos/RUGBY/SCREEN/EN/Full Color/CUGA-WM-rugby-en-fullColor-rgb.svg" alt="Underwater Rugby Logo" class="h-10 mr-3 inline-block align-middle">Underwater Rugby
                     </h3>
                     <img src="images/rugby.jpg" alt="Image of Underwater Rugby players" class="rounded-lg mb-6 w-full h-auto object-cover">
                     <p class="text-gray-700 leading-relaxed mb-6">
@@ -312,7 +312,7 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="300">
                     <h3 class="text-2xl font-bold mb-4 text-purple-800 flex items-center">
-                        <img src="assets/logos/FOOTBALL/SCREEN/EN/UWFootball_En_Purple.svg" alt="Underwater Football Logo" class="h-10 mr-3 inline-block align-middle">Underwater Football
+                        <img src="assets/logos/FOOTBALL/SCREEN/EN/Full Color/CUGA-WM-football-en-fullColor-rgb.svg" alt="Underwater Football Logo" class="h-10 mr-3 inline-block align-middle">Underwater Football
                     </h3>
                     <!-- <img src="images/logos/uwf-logo.jpg" alt="Underwater Football Full Logo" class="w-full max-w-xs mx-auto mb-6 rounded bg-white shadow" /> -->
                     <!-- Placeholder for an action image if available in future -->

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
 
     <div class="lang-fr">
         <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-            <div class="mx-auto text-2xl font-bold">CUGA</div>
+            <img src="assets/logos/CUGA/Horizontal/FR/CUGA_Hor_FR_Bleu.svg" alt="CUGA Logo" class="h-12 mx-auto">
             <p class="mt-1 text-md md:text-lg italic">Association Canadienne des Jeux Subaquatiques</p>
             <p class="mt-1 text-md md:text-lg italic">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p>
         </header>
@@ -116,7 +116,7 @@
             <div class="flex flex-col md:flex-row gap-10">
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="100">
                     <h3 class="text-2xl font-bold mb-4 text-blue-800 flex items-center text-center">
-                        Hockey Subaquatique
+                        <img src="assets/logos/HOCKEY/SCREEN/FR/UWHockey_Fr_Bleu.svg" alt="Hockey Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Hockey Subaquatique
                     </h3>
                     <img src="images/hockey.jpg" alt="Image de joueurs de Hockey Subaquatique" class="rounded-lg mb-6 w-full h-auto object-cover">
                     <p class="text-gray-700 leading-relaxed mb-6">
@@ -130,7 +130,7 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="200">
                     <h3 class="text-2xl font-bold mb-4 text-green-800 flex items-center text-center">
-                        Rugby Subaquatique
+                        <img src="assets/logos/RUGBY/SCREEN/FR/UWRugby_Fr_Vert.svg" alt="Rugby Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Rugby Subaquatique
                     </h3>
                     <img src="images/rugby.jpg" alt="Image de joueurs de Rugby Subaquatique" class="rounded-lg mb-6 w-full h-auto object-cover">
                     <p class="text-gray-700 leading-relaxed mb-6">
@@ -144,9 +144,8 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="300">
                     <h3 class="text-2xl font-bold mb-4 text-purple-800 flex items-center text-center">
-                        Football Subaquatique
+                        <img src="assets/logos/FOOTBALL/SCREEN/FR/UWFootball_Fr_Mauve.svg" alt="Football Subaquatique Logo" class="h-10 mr-3 inline-block align-middle">Football Subaquatique
                     </h3>
-                    <!-- Placeholder for a logo if available in future -->
                     <!-- <img src="images/logos/uwf-logo.jpg" alt="Logo Football Subaquatique" class="w-full max-w-xs mx-auto mb-6 rounded bg-white shadow" /> -->
                     <!-- Placeholder for an action image if available in future -->
                     <!-- <img src="images/football-action.jpg" alt="Image de joueurs de Football Subaquatique" class="rounded-lg mb-6 w-full h-auto object-cover"> -->
@@ -273,7 +272,7 @@
 
     <div class="lang-en">
         <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-            <div class="mx-auto text-2xl font-bold">CUGA</div>
+            <img src="assets/logos/CUGA/Horizontal/EN/CUGA_Hor_EN_Blue.svg" alt="CUGA Logo" class="h-12 mx-auto">
             <p class="mt-1 text-md md:text-lg italic">Canadian Underwater Games Association</p>
             <p class="mt-1 text-md md:text-lg italic">Dive into the action with Underwater Hockey and Underwater Rugby!</p>
         </header>
@@ -285,7 +284,7 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="100">
                     <h3 class="text-2xl font-bold mb-4 text-blue-800 flex items-center">
-                        Underwater Hockey
+                        <img src="assets/logos/HOCKEY/SCREEN/EN/UWHockey_En_Blue.svg" alt="Underwater Hockey Logo" class="h-10 mr-3 inline-block align-middle">Underwater Hockey
                     </h3>
                     <img src="images/hockey.jpg" alt="Image of Underwater Hockey players" class="rounded-lg mb-6 w-full h-auto object-cover">
                     <p class="text-gray-700 leading-relaxed mb-6">
@@ -299,7 +298,7 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="200">
                     <h3 class="text-2xl font-bold mb-4 text-green-800 flex items-center">
-                        Underwater Rugby
+                        <img src="assets/logos/RUGBY/SCREEN/EN/UWRugby_En_Green.svg" alt="Underwater Rugby Logo" class="h-10 mr-3 inline-block align-middle">Underwater Rugby
                     </h3>
                     <img src="images/rugby.jpg" alt="Image of Underwater Rugby players" class="rounded-lg mb-6 w-full h-auto object-cover">
                     <p class="text-gray-700 leading-relaxed mb-6">
@@ -313,10 +312,8 @@
 
                 <div class="bg-white rounded-xl shadow-xl p-8 w-full md:w-1/2 transform transition duration-500 hover:scale-105 hover:shadow-2xl" data-aos="fade-up" data-aos-delay="300">
                     <h3 class="text-2xl font-bold mb-4 text-purple-800 flex items-center">
-                        <!-- Icon placeholder if one exists, e.g., <img src="images/logos/uwf-icon.png" alt="Underwater Football Icon" class="w-8 h-8 rounded bg-white shadow mr-2" /> -->
-                        Underwater Football
+                        <img src="assets/logos/FOOTBALL/SCREEN/EN/UWFootball_En_Purple.svg" alt="Underwater Football Logo" class="h-10 mr-3 inline-block align-middle">Underwater Football
                     </h3>
-                    <!-- Placeholder for a logo if available in future -->
                     <!-- <img src="images/logos/uwf-logo.jpg" alt="Underwater Football Full Logo" class="w-full max-w-xs mx-auto mb-6 rounded bg-white shadow" /> -->
                     <!-- Placeholder for an action image if available in future -->
                     <!-- <img src="images/football-action.jpg" alt="Image of Underwater Football players" class="rounded-lg mb-6 w-full h-auto object-cover"> -->


### PR DESCRIPTION
I've incorporated logos into the main page (`index.html`) to enhance visual appeal and brand recognition.

Changes include:
- Added the main CUGA logo to the header in both French and English site versions.
- Added specific logos for Underwater Hockey, Underwater Rugby, and Underwater Football to their respective sections in both language versions.
- Ensured appropriate alt text and styling for all new images.