### PR TITLE
 'About Us' and 'CUGA Executive' sections t

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,31 @@
             <p class="text-lg text-gray-900 mt-4 leading-relaxed">CUGA est ravi d'organiser les Championnats Canadiens de Hockey Subaquatique 2025 à Gatineau! Venez encourager les meilleures équipes du pays.</p>
         </section>
 
+        <section id="about-us-fr" class="container mx-auto px-4 py-16" data-aos="fade-up">
+            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">À propos de nous</h2>
+            <div class="bg-white rounded-xl shadow-xl p-8 text-gray-700 leading-relaxed">
+                <p class="mb-4">L'Association Canadienne des Jeux Subaquatiques (CUGA) supervise les sports subaquatiques au Canada. CUGA a été fondée en 1984 et est devenue l'unique représentante canadienne pour les sports subaquatiques auprès de la CMAS, l'organisme international régissant les jeux subaquatiques.</p>
+                <p class="mb-4">CUGA est enregistrée comme une association athlétique amateur auprès de Revenu Canada et est strictement une organisation à but non lucratif, gérée par des bénévoles de partout au Canada.</p>
+                <p class="mb-4">CUGA travaille à réglementer et à promouvoir tous les jeux subaquatiques reconnus par la fédération internationale des sports subaquatiques (CMAS) au Canada. Ceux-ci incluent le hockey subaquatique, le rugby/football subaquatique, l'orientation subaquatique, la nage avec palmes et le tir sur cible.</p>
+                <p class="mb-4">Actuellement, le hockey subaquatique et le rugby/football subaquatique sont les seuls sports actifs au Canada avec des équipes participantes en Colombie-Britannique, Alberta, Saskatchewan, Ontario, Québec, Nouvelle-Écosse et au Yukon.</p>
+                <p class="mb-4">L'organisation soutient également les équipes nationales représentatives canadiennes qui participent aux championnats du monde et aux tournois sur invitation. CUGA offre une voix et un vote aux sports subaquatiques canadiens au niveau international pour la CMAS et/ou d'autres organismes internationaux régissant ces sports.</p>
+                <p>La mission de CUGA est de promouvoir et de développer les sports subaquatiques au Canada.</p>
+            </div>
+        </section>
+
+        <section id="executive-fr" class="container mx-auto px-4 py-16" data-aos="fade-up">
+            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">Exécutif actuel de CUGA (juin 2025) :</h2>
+            <div class="bg-white rounded-xl shadow-xl p-8 text-gray-700 leading-relaxed">
+                <ul class="list-disc pl-5 space-y-2">
+                    <li><strong>Président(e)</strong> (<a href="mailto:president@cuga.org" class="text-blue-600 hover:underline">president@cuga.org</a>): Alita Krickan</li>
+                    <li><strong>Vice-président(e)</strong> (<a href="mailto:vicepresident@cuga.org" class="text-blue-600 hover:underline">vicepresident@cuga.org</a>): Gillian Parker</li>
+                    <li><strong>Trésorier(-ière)</strong> (<a href="mailto:finance@cuga.org" class="text-blue-600 hover:underline">finance@cuga.org</a>): Emmanuel Martin</li>
+                    <li><strong>Secrétaire</strong> (<a href="mailto:info@cuga.org" class="text-blue-600 hover:underline">info@cuga.org</a>): Ben Lee</li>
+                    <li><strong>Membre du conseil - Technologie</strong> (<a href="mailto:tech@cuga.org" class="text-blue-600 hover:underline">tech@cuga.org</a>): Ricky Ng-Adam</li>
+                </ul>
+            </div>
+        </section>
+
          <section id="contact" class="bg-gray-800 text-white px-4 py-16">
             <div class="container mx-auto text-center">
                 <h2 class="text-3xl md:text-4xl font-semibold mb-8">Contactez CUGA</h2>
@@ -300,6 +325,31 @@
             <p class="text-xl text-gray-900 mb-2"><strong>Date:</strong> Friday, June 13, 2025 - Sunday, June 15, 2025</p>
             <p class="text-xl text-gray-900 mb-2"><strong>Location:</strong> Gatineau Sports Centre, 850 Bd de la Gappe, Gatineau, QC J8T 7T7</p>
             <p class="text-lg text-gray-900 mt-4 leading-relaxed">CUGA is thrilled to host the 2025 Canadian Underwater Hockey Nationals in Gatineau! Come and support the best teams in the country.</p>
+        </section>
+
+        <section id="about-us-en" class="container mx-auto px-4 py-16" data-aos="fade-up">
+            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">About Us</h2>
+            <div class="bg-white rounded-xl shadow-xl p-8 text-gray-700 leading-relaxed">
+                <p class="mb-4">The Canadian Underwater Games Association (CUGA) oversees underwater sports in Canada. CUGA was founded in 1984 and became the sole Canadian representative for underwater sports to CMAS, the international underwater games governing body.</p>
+                <p class="mb-4">CUGA is registered as an amateur athletic association with Revenue Canada and is strictly a non-profit organization, manned by volunteers from across Canada.</p>
+                <p class="mb-4">CUGA works to regulate and promote all underwater games recognized by the international underwater sport federation(CMAS) in Canada. These include underwater hockey, underwater rugby/football, underwater orienteering, fin swimming and target shooting.</p>
+                <p class="mb-4">At this time underwater hockey and underwater rugby/football are the only active sports in Canada with participating teams in British Columbia, Alberta, Saskatchewan, Ontario, Quebec, Nova Scotia and the Yukon.</p>
+                <p class="mb-4">The organization also supports Canadian national representative teams who compete at the world championships and invitational tournaments. CUGA provides a voice and a vote for Canadian Underwater Sports at the International Level for CMAS and/or other International bodies governing these sports.</p>
+                <p>CUGA’s mission is to promote and grow underwater sports in Canada.</p>
+            </div>
+        </section>
+
+        <section id="executive-en" class="container mx-auto px-4 py-16" data-aos="fade-up">
+            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">Current CUGA Executive (June 2025):</h2>
+            <div class="bg-white rounded-xl shadow-xl p-8 text-gray-700 leading-relaxed">
+                <ul class="list-disc pl-5 space-y-2">
+                    <li><strong>President</strong> (<a href="mailto:president@cuga.org" class="text-blue-600 hover:underline">president@cuga.org</a>): Alita Krickan</li>
+                    <li><strong>Vice President</strong> (<a href="mailto:vicepresident@cuga.org" class="text-blue-600 hover:underline">vicepresident@cuga.org</a>): Gillian Parker</li>
+                    <li><strong>Treasurer</strong> (<a href="mailto:finance@cuga.org" class="text-blue-600 hover:underline">finance@cuga.org</a>): Emmanuel Martin</li>
+                    <li><strong>Secretary</strong> (<a href="mailto:info@cuga.org" class="text-blue-600 hover:underline">info@cuga.org</a>): Ben Lee</li>
+                    <li><strong>Board member - Technology</strong> (<a href="mailto:tech@cuga.org" class="text-blue-600 hover:underline">tech@cuga.org</a>): Ricky Ng-Adam</li>
+                </ul>
+            </div>
         </section>
 
          <section id="contact-en" class="bg-gray-800 text-white px-4 py-16">


### PR DESCRIPTION
Added 'About Us' and 'CUGA Executive' sections to the main page (index.html).

These new sections provide information about the Canadian Underwater Games Association (CUGA), its history, mission, and details of the current executive members including their roles and contact emails.

 implemented these additions in both French and English versions of the page, maintaining the existing structure and styling. You'll find the content placed before the contact information section in each language view.