### PR TITLE
feat: Add Gemini-based iCalendar generation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,21 @@ The site provides information about underwater sports in Canada, primarily focus
 It also features a directory of underwater sports clubs across Canada.
 
 This website is a fork and modification of the original camosub.ca codebase.
+
+## Event Calendar (.ics) Generation
+
+This repository includes an automated system for generating iCalendar (`.ics`) files for club events. These files can be imported into most calendar applications.
+
+### Overview
+
+-   **Script**: The `generate_ics.js` Node.js script located in the root directory is responsible for fetching club schedule data from the same Google Sheet used by `cuga.html`. It then processes this data and uses the Google Gemini API to generate iCalendar event information.
+-   **Output**: Generated `.ics` files, typically one for each club or event series, are stored in the `/events` directory.
+-   **Automation**: The process is automated by a GitHub Actions workflow defined in `.github/workflows/generate_events_ics.yml`. This workflow runs daily, executes the `generate_ics.js` script, and commits any new or updated `.ics` files back to the `events/` directory in the repository.
+
+### Setup for Automation
+
+For the automated workflow to successfully generate and update `.ics` files, a repository secret must be configured in your GitHub repository settings:
+
+-   **`GEMINI_API_KEY`**: You must add your Google Gemini API key as a secret named `GEMINI_API_KEY`. This can be found under your repository's `Settings` > `Secrets and variables` > `Actions` > `New repository secret`.
+
+Without this secret, the `generate_ics.js` script will fail when attempting to contact the Gemini API, and no `.ics` files will be generated or updated.


### PR DESCRIPTION
This commit introduces an automated system to generate iCalendar (.ics) files from club data sourced from a Google Sheet.

Key changes include:

1.  **`generate_ics.js` (Node.js script):**
    - Fetches data from the Google Sheet.
    - For each club, constructs a detailed prompt for the Gemini API, including multilingual information (English/French for club name, sport type, location, practice times, notes), RRULE, and timezone.
    - Calls the Gemini API to generate iCalendar data.
    - Saves the generated .ics file into the `events/` directory, one file per club/event series.
    - Requires a `GEMINI_API_KEY` environment variable.

2.  **`package.json` and `package-lock.json`:**
    - Define Node.js project dependencies: `@google/generative-ai` and `node-fetch@2`.

3.  **`.github/workflows/generate_events_ics.yml` (GitHub Action):**
    - Automates the ICS generation process.
    - Triggers daily on a schedule and can be manually dispatched.
    - Sets up Node.js, installs dependencies (`npm ci`).
    - Runs `generate_ics.js`, providing the `GEMINI_API_KEY` from repository secrets.
    - Commits any new or modified .ics files in the `events/` directory back to the repository.

4.  **`README.md` Update:**
    - Added a new section explaining the ICS generation feature, the script, the workflow, and the critical requirement to set the `GEMINI_API_KEY` as a repository secret for the automation to work.

5.  **`.gitignore`:**
    - Ensures `node_modules/` is ignored.

I faced some initial challenges with handling `npm install`, which I worked around by manually defining `package.json` and `package-lock.json` and deferring the actual `npm install` to the GitHub Actions workflow. I also occasionally had to re-attempt or carefully verify completed actions.