### PR TITLE
feat: Implement persistent language selection

### DIFF
--- a/cuga.html
+++ b/cuga.html
@@ -670,11 +670,17 @@
 
                 document.documentElement.lang = lang;
                 displayClubs(lang);
+                localStorage.setItem('language', lang); // Store language choice
             };
 
-            const browserLang = (navigator.language || navigator.userLanguage || 'fr').slice(0, 2);
-            const initialLang = (browserLang === 'en' || browserLang === 'fr') ? browserLang : 'fr';
-            setLanguage(initialLang);
+            const storedLang = localStorage.getItem('language');
+            if (storedLang) {
+                setLanguage(storedLang);
+            } else {
+                const browserLang = (navigator.language || navigator.userLanguage || 'fr').slice(0, 2);
+                const initialLang = (browserLang === 'en' || browserLang === 'fr') ? browserLang : 'fr';
+                setLanguage(initialLang);
+            }
 
             langButtons.forEach(button => {
                 button.addEventListener('click', () => setLanguage(button.dataset.lang));

--- a/index.html
+++ b/index.html
@@ -504,24 +504,26 @@
                     button.classList.toggle('text-gray-800', button.dataset.lang !== lang);
                 });
                 document.documentElement.lang = lang;
+                localStorage.setItem('language', lang); // Store language choice
             };
 
-            // Auto-detect browser language
-            const browserLang = (navigator.language || navigator.userLanguage || 'fr').slice(0, 2);
-
-if (browserLang === 'en') {
-    setLanguage('en');
-} else {
-    // Default to French for 'fr' or any other detected language not explicitly handled as 'en'
-    setLanguage('fr');
-}
+            // Language initialization logic
+            const storedLang = localStorage.getItem('language');
+            if (storedLang) {
+                setLanguage(storedLang);
+            } else {
+                // Existing browser language detection logic
+                const browserLang = (navigator.language || navigator.userLanguage || 'fr').slice(0, 2);
+                if (browserLang === 'en') {
+                    setLanguage('en');
+                } else {
+                    setLanguage('fr'); // Default to French
+                }
+            }
 
             langButtons.forEach(button => {
                 button.addEventListener('click', () => setLanguage(button.dataset.lang));
             });
-
-            // The initial setLanguage call based on default 'fr' is now handled by the auto-detection logic.
-            // If no specific language is detected and matches 'en' or 'fr', it defaults to 'fr'.
         });
     </script>
     <script>

--- a/join.html
+++ b/join.html
@@ -253,14 +253,19 @@
                     button.classList.toggle('bg-gray-400', button.dataset.lang !== lang); // Inactive language button
                     button.classList.toggle('text-gray-800', button.dataset.lang !== lang);
                 });
+                localStorage.setItem('language', lang); // Store language choice
             };
 
-            // Auto-detect browser language
-            const browserLang = (navigator.language || navigator.userLanguage || 'fr').slice(0, 2);
-            // Set initial language: 'en' if browser is English, otherwise default to 'fr'
-            const initialLang = browserLang === 'en' ? 'en' : 'fr';
-            setLanguage(initialLang);
-
+            // Language initialization logic
+            const storedLang = localStorage.getItem('language');
+            if (storedLang) {
+                setLanguage(storedLang);
+            } else {
+                // Original browser language detection and initial setLanguage call
+                const browserLang = (navigator.language || navigator.userLanguage || 'fr').slice(0, 2);
+                const initialLang = browserLang === 'en' ? 'en' : 'fr';
+                setLanguage(initialLang);
+            }
 
             langButtons.forEach(button => {
                 button.addEventListener('click', () => setLanguage(button.dataset.lang));

--- a/waiver.html
+++ b/waiver.html
@@ -424,11 +424,18 @@
                 if (waiverInitialsInput) {
                     waiverInitialsInput.placeholder = lang === 'fr' ? waiverInitialsInput.getAttribute('placeholder-lang-fr') : waiverInitialsInput.getAttribute('placeholder-lang-en');
                 }
+                localStorage.setItem('language', lang); // Store language choice
             }
 
-            const browserLang = (navigator.language || navigator.userLanguage || 'fr').slice(0, 2);
-            const initialLang = browserLang === 'en' ? 'en' : 'fr';
-            updateDisplayedLanguage(initialLang);
+            const storedLang = localStorage.getItem('language');
+            if (storedLang) {
+                updateDisplayedLanguage(storedLang);
+            } else {
+                // Original browser language detection and initial updateDisplayedLanguage call
+                const browserLang = (navigator.language || navigator.userLanguage || 'fr').slice(0, 2);
+                const initialLang = browserLang === 'en' ? 'en' : 'fr';
+                updateDisplayedLanguage(initialLang);
+            }
 
             langButtons.forEach(button => {
                 button.addEventListener('click', () => updateDisplayedLanguage(button.dataset.lang));


### PR DESCRIPTION
This commit introduces persistent language selection across the website. Your chosen language (French or English) is now saved in localStorage and automatically applied when navigating between pages or reloading a page.

The following files were modified:
- index.html
- cuga.html
- join.html
- waiver.html

In each of these files, the JavaScript responsible for language switching has been updated:
1. When a language is selected, the choice ('fr' or 'en') is stored in `localStorage` under the key 'language'.
2. On page load (DOMContentLoaded), the script now first checks `localStorage` for a saved language preference.
3. If a preference is found, it is applied.
4. If no preference is found in `localStorage` (e.g., first visit or after clearing site data), the existing logic of detecting the browser's language (defaulting to French if not English) is used.

This ensures a consistent language experience for you as you navigate the site.