### PR TITLE
Refactor preview workflow for robust multi-PR preview aggregation

### DIFF
--- a/.github/workflows/preview-pages.yml
+++ b/.github/workflows/preview-pages.yml
@@ -196,58 +196,59 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Corrected: github-token
           script: |
-            const currentPRNumber = context.payload.pull_request.number;
-            // Default to empty array string if env var is missing or empty
-            const prsInfoString = process.env.PRS_INFO_JSON || '[]';
+            async function run() {
+              const currentPRNumber = context.payload.pull_request.number;
+              const prsInfoJson = process.env.PRS_INFO_JSON || '[]';
 
-            let allPRs = [];
-            try {
-              allPRs = JSON.parse(prsInfoString);
-              if (!Array.isArray(allPRs)) {
-                core.warning('Parsed PRS_INFO_JSON was not an array. Defaulting to empty array. Input was: ' + prsInfoString);
+              let allPRs = [];
+              try {
+                allPRs = JSON.parse(prsInfoJson);
+                if (!Array.isArray(allPRs)) {
+                  core.warning(`Parsed PRS_INFO_JSON was not an array. Input: "${prsInfoJson}". Defaulting to empty array.`);
+                  allPRs = [];
+                }
+              } catch (e) {
+                core.warning(`Could not parse PRS_INFO_JSON. Error: "${e.message}". Input: "${prsInfoJson}". Defaulting to empty array.`);
                 allPRs = [];
               }
-            } catch (e) {
-              core.warning("Could not parse PRS_INFO_JSON to list other PRs in comment: " + e.message + ". Input was: " + prsInfoString);
-              allPRs = [];
+
+              const otherPRNumbers = allPRs
+                .map(pr => pr.number)
+                .filter(num => num !== currentPRNumber);
+
+              const cnameDomain = process.env.CNAME_DOMAIN;
+              let previewUrlRoot = '';
+
+              if (cnameDomain && cnameDomain.trim() !== '') {
+                previewUrlRoot = `https://${cnameDomain.trim()}`;
+              } else {
+                previewUrlRoot = `https://${context.repo.owner}.github.io/${context.repo.repo}`;
+                core.warning('CNAME_DOMAIN environment variable not found or empty. Using default GitHub Pages URL for PR comment.');
+              }
+
+              const prPreviewPath = `/previews/${currentPRNumber}/`;
+              const specificPreviewUrl = `${previewUrlRoot}${prPreviewPath}`;
+
+              let messageBody = `🎉 Preview for this PR (#${currentPRNumber}) deployed at: [View Preview](${specificPreviewUrl})\n\n`;
+              messageBody += `The base site content is from the \`main\` branch. A global \`version.json\` at [${previewUrlRoot}/version.json](${previewUrlRoot}/version.json) lists all included PRs and the base \`main\` commit SHA.\n`;
+              messageBody += `Each PR's preview directory also contains a specific \`version.json\` for that PR's content.\n\n`;
+
+              if (otherPRNumbers.length > 0) {
+                messageBody += `This deployment also contains previews for other active PRs: ${otherPRNumbers.map(num => `#${num}`).join(', ')}.`;
+              } else {
+                messageBody += `This deployment does not include previews for any other active PRs at this time.`;
+              }
+
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: currentPRNumber,
+                  body: messageBody
+                });
+                console.log(`Comment posted on PR #${currentPRNumber}.`);
+              } catch (error) {
+                core.setFailed(`Failed to post comment on PR #${currentPRNumber}: ${error.message}`);
+              }
             }
-
-            // allPRs is now guaranteed to be an array, so direct map/filter is safe.
-            let otherPRNumbers = allPRs.map(pr => pr.number).filter(num => num !== currentPRNumber);
-
-            const cnameDomain = process.env.CNAME_DOMAIN;
-            let previewUrlRoot = '';
-
-            if (cnameDomain && cnameDomain.trim() !== '') {
-              previewUrlRoot = `https://${cnameDomain}`;
-            } else {
-              previewUrlRoot = `https://${context.repo.owner}.github.io/${context.repo.repo}`;
-              core.warning('CNAME_DOMAIN environment variable not found or empty. Using default GitHub Pages URL structure for PR comment.');
-            }
-
-            const prPreviewPath = `/previews/${currentPRNumber}/`;
-            const specificPreviewUrl = `${previewUrlRoot}${prPreviewPath}`;
-            const globalVersionJsonUrl = `${previewUrlRoot}/version.json`;
-
-            let messageBody = `🎉 Preview for this PR (#${currentPRNumber}) deployed at: [View Preview](${specificPreviewUrl})\n\n`;
-            messageBody += `The base site content is from the \`main\` branch. A global \`version.json\` at [${globalVersionJsonUrl}](${globalVersionJsonUrl}) lists all included PRs and the base \`main\` commit SHA.\n`;
-            messageBody += `Each PR's preview directory (including this one) also contains a specific \`version.json\` detailing its content (commit SHA, branch, PR number).\n\n`;
-
-            if (otherPRNumbers.length > 0) {
-              messageBody += `This deployment also contains previews for other active PRs: ${otherPRNumbers.map(num => \`#\${num}\`).join(', ')}.`;
-            } else {
-              messageBody += `This deployment does not include previews for any other active PRs at this time.`;
-            }
-
-            try {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: currentPRNumber,
-                body: messageBody
-              });
-              console.log(`Comment posted on PR #${currentPRNumber} with details of other included PRs and global version.json.`);
-            } catch (error) {
-              // Log the error and fail the step if commenting is critical
-              core.setFailed(`Failed to post comment on PR #${currentPRNumber}: ${error.message}`);
-            }
+            return run();


### PR DESCRIPTION
This commit significantly refactors the `preview-pages.yml` GitHub Actions workflow to correctly build and deploy a GitHub Pages site that includes previews for all active Pull Requests, each in its own subdirectory, alongside the main site content at the root.

Previously, each PR deployment would only contain the main site and its own preview, leading to subsequent deployments overwriting others' previews.

Key changes in the new workflow:
1.  On any PR event (open, synchronize, reopen): a. Fetches a list of all currently open PRs (`prs_info`). b. Prepares a `temp_deploy` staging directory. c. Checks out the `main` branch content into the root of `temp_deploy`. d. Creates a global `version.json` in `temp_deploy` listing the `main` branch commit and all PRs being processed. e. For each open PR identified in `prs_info`: i.  Checks out the PR's code into a temporary local directory. ii. Creates a PR-specific `version.json` within this temp directory. iii.Copies the PR's content into `temp_deploy/previews/PR_NUMBER/`. f. The `index.html` of the PR that triggered the workflow is linted. g. The entire `temp_deploy` directory (containing main site content at `/` and each PR's content at `/previews/PR_NUMBER/`) is uploaded as the artifact and deployed to GitHub Pages. h. A comment is posted on the triggering PR, providing a link to its specific preview path and also mentioning other PRs included in the deployment and the global `version.json`.

This ensures that each preview deployment is comprehensive, containing all currently active PR previews and the main site content, resolving the issue of PR-specific deployments overwriting each other.