### PR TITLE
Add link to CUGA bylaws in footer

### DIFF
--- a/cuga.html
+++ b/cuga.html
@@ -127,6 +127,7 @@
         <div class="container mx-auto px-4">
             <p>&copy; 2025 CUGA. Tous droits réservés.</p>
             <p class="mt-4">
+                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">Code de Conduite CUGA</a> |
                 <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
                 <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
                 <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
@@ -161,6 +162,7 @@
         <div class="container mx-auto px-4">
             <p>&copy; 2025 CUGA. All rights reserved.</p>
             <p class="mt-4">
+                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Code of Conduct</a> |
                 <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
                 <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
                 <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>

--- a/cuga.html
+++ b/cuga.html
@@ -127,7 +127,7 @@
         <div class="container mx-auto px-4">
             <p>&copy; 2025 CUGA. Tous droits réservés.</p>
             <p class="mt-4">
-                <a href="https://drive.google.com/file/d/1XsFqH70PiEXshiWF8WHmPBot3CTVtYD0/view?usp=sharing" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
+                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
                 <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
                 <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
             </p>
@@ -161,7 +161,7 @@
         <div class="container mx-auto px-4">
             <p>&copy; 2025 CUGA. All rights reserved.</p>
             <p class="mt-4">
-                <a href="https://drive.google.com/file/d/1XsFqH70PiEXshiWF8WHmPBot3CTVtYD0/view?usp=sharing" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
+                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
                 <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
                 <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>
             </p>

--- a/cuga.html
+++ b/cuga.html
@@ -127,6 +127,7 @@
         <div class="container mx-auto px-4">
             <p>&copy; 2025 CUGA. Tous droits réservés.</p>
             <p class="mt-4">
+                <a href="https://drive.google.com/file/d/1XsFqH70PiEXshiWF8WHmPBot3CTVtYD0/view?usp=sharing" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
                 <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
                 <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
             </p>
@@ -160,6 +161,7 @@
         <div class="container mx-auto px-4">
             <p>&copy; 2025 CUGA. All rights reserved.</p>
             <p class="mt-4">
+                <a href="https://drive.google.com/file/d/1XsFqH70PiEXshiWF8WHmPBot3CTVtYD0/view?usp=sharing" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
                 <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
                 <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>
             </p>

--- a/index.html
+++ b/index.html
@@ -253,39 +253,41 @@
         </section>
 
         </main>
-        <footer class="bg-gray-900 text-gray-400 py-8 text-center">
-            <div class="container mx-auto px-4">
-                <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                    <span>
-                        <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
-                        <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                            Association Canadienne des Jeux Sous-Marins
-                        </a>
-                    </span>
-                    <span class="mx-2">|</span>
-                    <span>
-                        <i class="fa fa-globe text-green-200 mr-1"></i>
-                        <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                            CMAS Hockey subaquatique
-                        </a>
-                    </span>
-                    <span class="mx-2">|</span>
-                    <span>
-                        <i class="fa fa-globe text-green-200 mr-1"></i>
-                        <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                            CMAS Rugby subaquatique
-                        </a>
-                    </span>
-                </p>
-            </div>
-            <div class="container mx-auto px-4">
-                <p>&copy; 2025 CUGA. Tous droits réservés.</p>
-                <p class="mt-4">
-                    <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
-                    <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
-                </p>
-            </div>
-        </footer>
+    <footer id="footer-fr" class="bg-gray-900 text-gray-400 py-8 text-center">
+        <div class="container mx-auto px-4">
+            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
+                <span>
+                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
+                    <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        Association Canadienne des Jeux Sous-Marins
+                    </a>
+                </span>
+                <span class="mx-2">|</span>
+                <span>
+                    <i class="fa fa-globe text-green-200 mr-1"></i>
+                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CMAS Hockey subaquatique
+                    </a>
+                </span>
+                <span class="mx-2">|</span>
+                <span>
+                    <i class="fa fa-globe text-green-200 mr-1"></i>
+                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CMAS Rugby subaquatique
+                    </a>
+                </span>
+            </p>
+        </div>
+        <div class="container mx-auto px-4">
+            <p>&copy; 2025 CUGA. Tous droits réservés.</p>
+            <p class="mt-4">
+                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">Code de Conduite CUGA</a> |
+                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
+                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
+                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
+            </p>
+        </div>
+    </footer>
     </div>
 
     <div class="lang-en">
@@ -406,39 +408,41 @@
         </section>
 
         </main>
-        <footer class="bg-gray-900 text-gray-400 py-8 text-center">
-            <div class="container mx-auto px-4">
-                <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                    <span>
-                        <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
-                        <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                            CUGA (Canadian Underwater Games Association)
-                        </a>
-                    </span>
-                    <span class="mx-2">|</span>
-                    <span>
-                        <i class="fa fa-globe text-green-200 mr-1"></i>
-                        <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                            CMAS Underwater Hockey
-                        </a>
-                    </span>
-                    <span class="mx-2">|</span>
-                    <span>
-                        <i class="fa fa-globe text-green-200 mr-1"></i>
-                        <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                            CMAS Underwater Rugby
-                        </a>
-                    </span>
-                </p>
-            </div>
-            <div class="container mx-auto px-4">
-                <p>&copy; 2025 CUGA. All rights reserved.</p>
-                <p class="mt-4">
-                    <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
-                    <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>
-                </p>
-            </div>
-        </footer>
+    <footer id="footer-en" class="bg-gray-900 text-gray-400 py-8 text-center hidden">
+        <div class="container mx-auto px-4">
+            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
+                <span>
+                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
+                    <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CUGA (Canadian Underwater Games Association)
+                    </a>
+                </span>
+                <span class="mx-2">|</span>
+                <span>
+                    <i class="fa fa-globe text-green-200 mr-1"></i>
+                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CMAS Underwater Hockey
+                    </a>
+                </span>
+                <span class="mx-2">|</span>
+                <span>
+                    <i class="fa fa-globe text-green-200 mr-1"></i>
+                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CMAS Underwater Rugby
+                    </a>
+                </span>
+            </p>
+        </div>
+        <div class="container mx-auto px-4">
+            <p>&copy; 2025 CUGA. All rights reserved.</p>
+            <p class="mt-4">
+                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Code of Conduct</a> |
+                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
+                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
+                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>
+            </p>
+        </div>
+    </footer>
     </div>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
         </section>
 
         </main>
-    <footer id="footer-en" class="bg-gray-900 text-gray-400 py-8 text-center hidden">
+    <footer id="footer-en" class="bg-gray-900 text-gray-400 py-8 text-center">
         <div class="container mx-auto px-4">
             <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
                 <span>

--- a/join.html
+++ b/join.html
@@ -118,7 +118,8 @@
             <section>
                 <h2 class="text-2xl font-semibold text-blue-700 mb-4">Important Documents</h2>
                 <ul class="list-disc pl-6 space-y-2 text-gray-700">
-                    <li><a href="#code-of-conduct" id="code-of-conduct-link-en" class="text-blue-600 hover:underline">CUGA Code of Conduct</a> (Referenced in waiver form)</li>
+                    <li><a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" class="text-blue-600 hover:underline">CUGA Code of Conduct</a></li>
+                    <li><a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" class="text-blue-600 hover:underline">CUGA Bylaws</a></li>
                     <li><a href="#adult-waiver" id="adult-waiver-link-en" class="text-blue-600 hover:underline">CUGA Adult Waiver Example</a> (Referenced in waiver form)</li>
                     <li><a href="#minor-waiver" id="minor-waiver-link-en" class="text-blue-600 hover:underline">CUGA Minor Waiver Example</a> (Referenced in waiver form)</li>
                     <li><a href="privacy-policy.html" class="text-blue-600 hover:underline">CUGA Privacy Policy</a></li>
@@ -195,7 +196,8 @@
             <section>
                 <h2 class="text-2xl font-semibold text-blue-700 mb-4">Documents Importants</h2>
                 <ul class="list-disc pl-6 space-y-2 text-gray-700">
-                    <li><a href="#code-of-conduct" id="code-of-conduct-link-fr" class="text-blue-600 hover:underline">Code de Conduite de CUGA</a> (Référencé dans le formulaire de décharge)</li>
+                    <li><a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" class="text-blue-600 hover:underline">Code de Conduite de CUGA</a></li>
+                    <li><a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" class="text-blue-600 hover:underline">Règlements de la CUGA</a></li>
                     <li><a href="#adult-waiver" id="adult-waiver-link-fr" class="text-blue-600 hover:underline">Exemple de Décharge Adulte CUGA</a> (Référencé dans le formulaire de décharge)</li>
                     <li><a href="#minor-waiver" id="minor-waiver-link-fr" class="text-blue-600 hover:underline">Exemple de Décharge Mineur CUGA</a> (Référencé dans le formulaire de décharge)</li>
                     <li><a href="privacy-policy.html" class="text-blue-600 hover:underline">Politique de Confidentialité de CUGA</a></li>

--- a/join.html
+++ b/join.html
@@ -210,14 +210,73 @@
         </div>
     </main>
 
-    <footer class="bg-gray-900 text-gray-400 py-8 text-center">
+    <footer id="footer-fr" class="bg-gray-900 text-gray-400 py-8 text-center lang-fr">
         <div class="container mx-auto px-4">
-            <p>&copy; 2025 CUGA. All rights reserved. / Tous droits réservés.</p>
+            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
+                <span>
+                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
+                    <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        Association Canadienne des Jeux Sous-Marins
+                    </a>
+                </span>
+                <span class="mx-2">|</span>
+                <span>
+                    <i class="fa fa-globe text-green-200 mr-1"></i>
+                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CMAS Hockey subaquatique
+                    </a>
+                </span>
+                <span class="mx-2">|</span>
+                <span>
+                    <i class="fa fa-globe text-green-200 mr-1"></i>
+                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CMAS Rugby subaquatique
+                    </a>
+                </span>
+            </p>
+        </div>
+        <div class="container mx-auto px-4">
+            <p>&copy; 2025 CUGA. Tous droits réservés.</p>
             <p class="mt-4">
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline lang-en">Privacy Policy</a>
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline lang-fr" style="display:none;">Politique de Confidentialité</a> |
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline lang-en">Terms of Use</a>
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline lang-fr" style="display:none;">Conditions d'Utilisation</a>
+                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">Code de Conduite CUGA</a> |
+                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
+                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
+                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
+            </p>
+        </div>
+    </footer>
+    <footer id="footer-en" class="bg-gray-900 text-gray-400 py-8 text-center lang-en">
+        <div class="container mx-auto px-4">
+            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
+                <span>
+                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
+                    <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CUGA (Canadian Underwater Games Association)
+                    </a>
+                </span>
+                <span class="mx-2">|</span>
+                <span>
+                    <i class="fa fa-globe text-green-200 mr-1"></i>
+                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CMAS Underwater Hockey
+                    </a>
+                </span>
+                <span class="mx-2">|</span>
+                <span>
+                    <i class="fa fa-globe text-green-200 mr-1"></i>
+                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
+                        CMAS Underwater Rugby
+                    </a>
+                </span>
+            </p>
+        </div>
+        <div class="container mx-auto px-4">
+            <p>&copy; 2025 CUGA. All rights reserved.</p>
+            <p class="mt-4">
+                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Code of Conduct</a> |
+                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
+                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
+                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>
             </p>
         </div>
     </footer>


### PR DESCRIPTION
This change adds a link to the CUGA bylaws in the footer of the cuga.html page. The link is available in both English and French versions of the footer and points to the Google Drive document provided in the issue.