### PR TITLE
Update championship results and embed video

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,19 @@
             <p class="text-xl text-gray-900 mb-2"><strong>Date :</strong> Vendredi 13 juin 2025 - Dimanche 15 juin 2025</p>
             <p class="text-xl text-gray-900 mb-2"><strong>Lieu :</strong> Centre Sportif de Gatineau, 850 Bd de la Gappe, Gatineau, QC J8T 7T7</p>
             <p class="text-lg text-gray-900 mt-4 leading-relaxed">CUGA est ravi d'organiser les Championnats Canadiens de Hockey Subaquatique 2025 à Gatineau! Venez encourager les meilleures équipes du pays.</p>
+
+            <div class="mt-8">
+                <p class="text-lg text-gray-900 leading-relaxed">Voici les résultats du championnat :</p>
+                <ul class="list-disc list-inside text-left inline-block mt-4 text-gray-900">
+                    <li><strong>Or :</strong> Trash Pandas (Toronto)</li>
+                    <li><strong>Argent :</strong> CAMO (Montréal)</li>
+                    <li><strong>Bronze :</strong> Nautilus (Cornwall)</li>
+                </ul>
+            </div>
+
+            <div class="mt-8">
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/arUaXDDEz54" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen class="mx-auto rounded-lg shadow-xl"></iframe>
+            </div>
         </section>
 
         <section id="about-us-fr" class="container mx-auto px-4 py-16" data-aos="fade-up">
@@ -360,6 +373,19 @@
             <p class="text-xl text-gray-900 mb-2"><strong>Date:</strong> Friday, June 13, 2025 - Sunday, June 15, 2025</p>
             <p class="text-xl text-gray-900 mb-2"><strong>Location:</strong> Gatineau Sports Centre, 850 Bd de la Gappe, Gatineau, QC J8T 7T7</p>
             <p class="text-lg text-gray-900 mt-4 leading-relaxed">CUGA is thrilled to host the 2025 Canadian Underwater Hockey Nationals in Gatineau! Come and support the best teams in the country.</p>
+
+            <div class="mt-8">
+                <p class="text-lg text-gray-900 leading-relaxed">Here are the championship results:</p>
+                <ul class="list-disc list-inside text-left inline-block mt-4 text-gray-900">
+                    <li><strong>Gold:</strong> Trash Pandas (Toronto)</li>
+                    <li><strong>Silver:</strong> CAMO (Montréal)</li>
+                    <li><strong>Bronze:</strong> Nautilus (Cornwall)</li>
+                </ul>
+            </div>
+
+            <div class="mt-8">
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/arUaXDDEz54" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen class="mx-auto rounded-lg shadow-xl"></iframe>
+            </div>
         </section>
 
         <section id="about-us-en" class="container mx-auto px-4 py-16" data-aos="fade-up">

--- a/index.html
+++ b/index.html
@@ -200,11 +200,11 @@
         </div>
 
         <section id="nationals" class="container mx-auto px-4 py-16 text-center bg-gray-100 rounded-xl mb-16" data-aos="fade-up">
-            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-900">Championnats Canadiens de Hockey Subaquatique 2025</h2>
+            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-900">Les Championnats Canadiens de Hockey Subaquatique 2025 ont eu lieu</h2>
             <img src="competitions/2025-Canadian-Underwater-Hockey-Nationals.jpeg" alt="Affiche des Championnats Canadiens de Hockey Subaquatique 2025" class="rounded-lg mb-6 mx-auto shadow-xl w-full md:w-2/3 lg:w-1/2">
-            <p class="text-xl text-gray-900 mb-2"><strong>Date :</strong> Vendredi 13 juin 2025 - Dimanche 15 juin 2025</p>
+            <p class="text-xl text-gray-900 mb-2"><strong>Date :</strong> A eu lieu du Vendredi 13 juin 2025 au Dimanche 15 juin 2025</p>
             <p class="text-xl text-gray-900 mb-2"><strong>Lieu :</strong> Centre Sportif de Gatineau, 850 Bd de la Gappe, Gatineau, QC J8T 7T7</p>
-            <p class="text-lg text-gray-900 mt-4 leading-relaxed">CUGA est ravi d'organiser les Championnats Canadiens de Hockey Subaquatique 2025 à Gatineau! Venez encourager les meilleures équipes du pays.</p>
+            <p class="text-lg text-gray-900 mt-4 leading-relaxed">CUGA était ravi d'organiser les Championnats Canadiens de Hockey Subaquatique 2025 à Gatineau! Merci à tous ceux qui sont venus encourager les meilleures équipes du pays.</p>
 
             <div class="mt-8">
                 <p class="text-lg text-gray-900 leading-relaxed">Voici les résultats du championnat :</p>
@@ -368,11 +368,11 @@
         </div>
 
         <section id="nationals-en" class="container mx-auto px-4 py-16 text-center bg-gray-100 rounded-xl mb-16" data-aos="fade-up">
-            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-900">2025 Canadian Underwater Hockey Nationals</h2>
+            <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-900">The 2025 Canadian Underwater Hockey Nationals were held</h2>
             <img src="competitions/2025-Canadian-Underwater-Hockey-Nationals.jpeg" alt="2025 Canadian Underwater Hockey Nationals Poster" class="rounded-lg mb-6 mx-auto shadow-xl w-full md:w-2/3 lg:w-1/2">
-            <p class="text-xl text-gray-900 mb-2"><strong>Date:</strong> Friday, June 13, 2025 - Sunday, June 15, 2025</p>
+            <p class="text-xl text-gray-900 mb-2"><strong>Date:</strong> Took place from Friday, June 13, 2025 - Sunday, June 15, 2025</p>
             <p class="text-xl text-gray-900 mb-2"><strong>Location:</strong> Gatineau Sports Centre, 850 Bd de la Gappe, Gatineau, QC J8T 7T7</p>
-            <p class="text-lg text-gray-900 mt-4 leading-relaxed">CUGA is thrilled to host the 2025 Canadian Underwater Hockey Nationals in Gatineau! Come and support the best teams in the country.</p>
+            <p class="text-lg text-gray-900 mt-4 leading-relaxed">CUGA was thrilled to host the 2025 Canadian Underwater Hockey Nationals in Gatineau! Thanks to everyone who came out to support the best teams in the country.</p>
 
             <div class="mt-8">
                 <p class="text-lg text-gray-900 leading-relaxed">Here are the championship results:</p>

--- a/index.html
+++ b/index.html
@@ -218,6 +218,7 @@
             <div class="mt-8">
                 <iframe width="560" height="315" src="https://www.youtube.com/embed/arUaXDDEz54" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen class="mx-auto rounded-lg shadow-xl"></iframe>
             </div>
+            <iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Fcuga.org%2Fposts%2Fpfbid0xnVffaB1ah2U6sc2aSjjnPJhtRfY6fxzuPgzSud35YbKvV22JokdjEC8tGE5o7E9l&show_text=true&width=500" width="500" height="729" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share" class="mx-auto mt-8"></iframe>
         </section>
 
         <section id="about-us-fr" class="container mx-auto px-4 py-16" data-aos="fade-up">
@@ -386,6 +387,7 @@
             <div class="mt-8">
                 <iframe width="560" height="315" src="https://www.youtube.com/embed/arUaXDDEz54" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen class="mx-auto rounded-lg shadow-xl"></iframe>
             </div>
+            <iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Fcuga.org%2Fposts%2Fpfbid0xnVffaB1ah2U6sc2aSjjnPJhtRfY6fxzuPgzSud35YbKvV22JokdjEC8tGE5o7E9l&show_text=true&width=500" width="500" height="729" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share" class="mx-auto mt-8"></iframe>
         </section>
 
         <section id="about-us-en" class="container mx-auto px-4 py-16" data-aos="fade-up">


### PR DESCRIPTION
This commit updates the French and English sections of the homepage (index.html) with the results from the 2025 Canadian Underwater Hockey National Championship.

The following changes were made:
- Added the Gold, Silver, and Bronze medal winners for both French and English content.
- Embedded the YouTube video of the final game in both language sections.
- Ensured consistent styling for the new elements.

The results are:
Gold: Trash Pandas (Toronto)
Silver: CAMO (Montréal)
Bronze: Nautilus (Cornwall)

The YouTube video URL is: https://youtu.be/arUaXDDEz54?si=929m584_qXgPCqY0