### PR TITLE
feat: Adjust header logo size, background, and text layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,10 +137,14 @@
     </div>
 
     <div class="lang-fr">
-        <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-            <img src="assets/logos/CUGA/Horizontal/FR/FullColor/CUGA-logo-h-fr-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto">
-            <p class="mt-1 text-md md:text-lg italic">Association Canadienne des Jeux Subaquatiques</p>
-            <p class="mt-1 text-md md:text-lg italic">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p>
+        <header class="bg-white shadow-lg py-4"> {/* Changed background, adjusted padding, removed text-center */}
+            <div class="container mx-auto flex items-center justify-start px-4"> {/* New wrapper div, items-center, justify-start */}
+                <img src="assets/logos/CUGA/Horizontal/FR/FullColor/CUGA-logo-h-fr-fullColor-rgb.svg" alt="CUGA Logo" class="h-24 mr-6"> {/* Increased height, removed mx-auto, added mr-6 */}
+                <div class="text-left"> {/* New div for text, text-left */}
+                    <p class="text-md md:text-lg italic text-black">Association Canadienne des Jeux Subaquatiques</p> {/* Text black, removed mt-1 */}
+                    <p class="text-md md:text-lg italic text-black">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p> {/* Text black, removed mt-1 */}
+                </div>
+            </div>
         </header>
         <main>
         <section id="sports" class="container mx-auto px-4 py-16" data-aos="fade-up">
@@ -321,10 +325,14 @@
     </div>
 
     <div class="lang-en">
-        <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-            <img src="assets/logos/CUGA/Horizontal/EN/FullColor/CUGA-logo-h-en-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto">
-            <p class="mt-1 text-md md:text-lg italic">Canadian Underwater Games Association</p>
-            <p class="mt-1 text-md md:text-lg italic">Dive into the action with Underwater Hockey and Underwater Rugby!</p>
+        <header class="bg-white shadow-lg py-4"> {/* Changed background, adjusted padding, removed text-center */}
+            <div class="container mx-auto flex items-center justify-start px-4"> {/* New wrapper div, items-center, justify-start */}
+                <img src="assets/logos/CUGA/Horizontal/EN/FullColor/CUGA-logo-h-en-fullColor-rgb.svg" alt="CUGA Logo" class="h-24 mr-6"> {/* Increased height, removed mx-auto, added mr-6 */}
+                <div class="text-left"> {/* New div for text, text-left */}
+                    <p class="text-md md:text-lg italic text-black">Canadian Underwater Games Association</p> {/* Text black, removed mt-1 */}
+                    <p class="text-md md:text-lg italic text-black">Dive into the action with Underwater Hockey and Underwater Rugby!</p> {/* Text black, removed mt-1 */}
+                </div>
+            </div>
         </header>
         <main>
         <section id="sports-en" class="container mx-auto px-4 py-16" data-aos="fade-up">


### PR DESCRIPTION
- Increased logo size in the main header.
- Set header background to white.
- Positioned logo to the left and descriptive text (in black) to the right using flexbox.
- Applied changes to both French and English versions of the header.