### PR TITLE
Change yellow accent color to black

### DIFF
--- a/cuga.html
+++ b/cuga.html
@@ -76,12 +76,12 @@
         </button>
     </div>
 
-    <div id="experimental-banner-container" class="text-center py-3 bg-yellow-300 text-black text-sm">
+    <div id="experimental-banner-container" class="text-center py-3 bg-gray-700 text-white text-sm">
         <div id="lang-en-banner">
-            This is an experimental website for CUGA. The official CUGA website can be found at <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-700">https://cuga.org/</a>.
+            This is an experimental website for CUGA. The official CUGA website can be found at <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-300">https://cuga.org/</a>.
         </div>
         <div id="lang-fr-banner" class="hidden">
-            Ceci est un site web expérimental pour CUGA. Le site officiel de CUGA se trouve à <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-700">https://cuga.org/</a>.
+            Ceci est un site web expérimental pour CUGA. Le site officiel de CUGA se trouve à <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-300">https://cuga.org/</a>.
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
             display: none; /* Hide English content by default to prevent flash and provide a no-JS fallback */
         }
         .active-nav-link {
-            color: #FACC15; /* Corresponds to Tailwind's yellow-400 */
+            color: #000;
             font-weight: bold;
         }
     </style>
@@ -101,23 +101,23 @@
 
     <nav class="lang-fr fixed top-1/2 right-4 transform -translate-y-1/2 bg-opacity-75 bg-blue-800 text-white p-3 rounded-lg z-50 shadow-md hidden lg:block force-hide-mobile">
         <ul class="flex flex-col space-y-2">
-            <li class="py-1"><a href="join.html" class="hover:text-yellow-300">Rejoindre CUGA</a></li>
-            <li class="py-1"><a href="#about-us-fr" class="hover:text-yellow-300">À propos</a></li>
-            <li class="py-1"><a href="#executive-fr" class="hover:text-yellow-300">Exécutif</a></li>
-            <li class="py-1"><a href="#sports" class="hover:text-yellow-300">Disciplines</a></li>
-            <li class="py-1"><a href="#nationals" class="hover:text-yellow-300">Championnats</a></li>
-            <li class="py-1"><a href="#contact" class="hover:text-yellow-300">Contact</a></li>
+            <li class="py-1"><a href="join.html" class="hover:text-gray-300">Rejoindre CUGA</a></li>
+            <li class="py-1"><a href="#about-us-fr" class="hover:text-gray-300">À propos</a></li>
+            <li class="py-1"><a href="#executive-fr" class="hover:text-gray-300">Exécutif</a></li>
+            <li class="py-1"><a href="#sports" class="hover:text-gray-300">Disciplines</a></li>
+            <li class="py-1"><a href="#nationals" class="hover:text-gray-300">Championnats</a></li>
+            <li class="py-1"><a href="#contact" class="hover:text-gray-300">Contact</a></li>
         </ul>
     </nav>
 
     <nav class="lang-en fixed top-1/2 right-4 transform -translate-y-1/2 bg-opacity-75 bg-blue-800 text-white p-3 rounded-lg z-50 shadow-md hidden lg:block force-hide-mobile">
         <ul class="flex flex-col space-y-2">
-            <li class="py-1"><a href="join.html" class="hover:text-yellow-300">Join CUGA</a></li>
-            <li class="py-1"><a href="#about-us-en" class="hover:text-yellow-300">About Us</a></li>
-            <li class="py-1"><a href="#executive-en" class="hover:text-yellow-300">Executive</a></li>
-            <li class="py-1"><a href="#sports-en" class="hover:text-yellow-300">Disciplines</a></li>
-            <li class="py-1"><a href="#nationals-en" class="hover:text-yellow-300">Nationals</a></li>
-            <li class="py-1"><a href="#contact-en" class="hover:text-yellow-300">Contact</a></li>
+            <li class="py-1"><a href="join.html" class="hover:text-gray-300">Join CUGA</a></li>
+            <li class="py-1"><a href="#about-us-en" class="hover:text-gray-300">About Us</a></li>
+            <li class="py-1"><a href="#executive-en" class="hover:text-gray-300">Executive</a></li>
+            <li class="py-1"><a href="#sports-en" class="hover:text-gray-300">Disciplines</a></li>
+            <li class="py-1"><a href="#nationals-en" class="hover:text-gray-300">Nationals</a></li>
+            <li class="py-1"><a href="#contact-en" class="hover:text-gray-300">Contact</a></li>
         </ul>
     </nav>
 
@@ -130,10 +130,10 @@
         </button>
     </div>
 
-    <div class="text-center py-3 bg-yellow-300 text-black text-sm">
-        This is an experimental website for CUGA. The official CUGA website can be found at <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-700">https://cuga.org/</a>.
+    <div class="text-center py-3 bg-gray-700 text-white text-sm">
+        This is an experimental website for CUGA. The official CUGA website can be found at <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-300">https://cuga.org/</a>.
         <br>
-        Ceci est un site web expérimental pour CUGA. Le site officiel de CUGA se trouve à <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-700">https://cuga.org/</a>.
+        Ceci est un site web expérimental pour CUGA. Le site officiel de CUGA se trouve à <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-300">https://cuga.org/</a>.
     </div>
 
     <div class="lang-fr">
@@ -194,7 +194,7 @@
         </section>
 
         <div class="container mx-auto px-4 py-8 text-center" data-aos="fade-up">
-            <a href="cuga.html" class="inline-block bg-yellow-500 text-gray-900 px-10 py-4 rounded-full font-bold text-xl hover:bg-yellow-600 transition duration-300 shadow-lg">
+            <a href="cuga.html" class="inline-block bg-gray-800 text-white px-10 py-4 rounded-full font-bold text-xl hover:bg-black transition duration-300 shadow-lg">
                 Voir la liste des clubs CUGA
             </a>
         </div>
@@ -379,7 +379,7 @@
         </section>
 
         <div class="container mx-auto px-4 py-8 text-center" data-aos="fade-up">
-            <a href="cuga.html" class="inline-block bg-yellow-500 text-gray-900 px-10 py-4 rounded-full font-bold text-xl hover:bg-yellow-600 transition duration-300 shadow-lg">
+            <a href="cuga.html" class="inline-block bg-gray-800 text-white px-10 py-4 rounded-full font-bold text-xl hover:bg-black transition duration-300 shadow-lg">
                 View CUGA Clubs List
             </a>
         </div>


### PR DESCRIPTION
- Replaced yellow accent color (#FACC15 and Tailwind yellow classes) with black (#000) or dark gray equivalents in index.html and cuga.html.
- Updated text and link hover colors for better visibility on darker backgrounds.