### PR TITLE
Apply styles.css to HTML pages and create todo.md

### DIFF
--- a/cuga.html
+++ b/cuga.html
@@ -12,8 +12,10 @@
     </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CUGA Clubs</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <title>CUGA Clubs - Canadian Underwater Games Association</title>
+    <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.tailwindcss.com"></script> <!-- Retaining Tailwind for existing content -->
     <link rel="stylesheet" href="assets/fontawesome/css/font-awesome.min.css">
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
@@ -85,11 +87,21 @@
         </div>
     </div>
 
-    <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-        <img id="cugaLogo" src="assets/logos/CUGA/Horizontal/FR/FullColor/CUGA-logo-h-fr-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto">
-        <p id="cugaSubtitle" class="mt-1 text-md md:text-lg italic">Association Canadienne des Jeux Subaquatiques</p>
-        <p id="cugaTagline" class="mt-1 text-md md:text-lg italic">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p>
+    <!-- Applying .site-header, .site-logo-link, .site-logo -->
+    <header class="site-header">
+        <a href="index.html" class="site-logo-link"> <!-- Assuming index.html is the home page -->
+            <img id="cugaLogo" src="assets/logos/CUGA/Horizontal/FR/FullColor/CUGA-logo-h-fr-fullColor-rgb.svg" alt="CUGA Logo" class="site-logo">
+        </a>
+        <!-- Hamburger menu button will be needed here for consistency if other pages have it -->
+        <!-- For now, leaving it out as this page has its own navigation (language buttons) -->
+        <!-- Note: The text-white, text-center, shadow-lg, py-8 Tailwind classes were removed -->
+        <!-- Subtitle and Tagline are outside the standard .site-header structure, will need custom styling or new classes -->
     </header>
+    <div class="text-center py-4" style="background-color: var(--primary-color); color: var(--white);"> <!-- Replicating old header visual for subtitle/tagline -->
+        <p id="cugaSubtitle" class="text-md md:text-lg italic">Association Canadienne des Jeux Subaquatiques</p>
+        <p id="cugaTagline" class="mt-1 text-md md:text-lg italic">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p>
+    </div>
+
 
     <div id="filter-controls" class="w-full px-4 py-8 bg-gray-100 text-gray-800 rounded-lg shadow-md">
         <!-- Filter controls will be added here -->
@@ -99,73 +111,69 @@
         <!-- Club listings will be displayed here -->
     </div>
 
-    <footer id="footer-fr" class="bg-gray-900 text-gray-400 py-8 text-center">
-        <div class="container mx-auto px-4">
-            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                <span>
-                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
-                    <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        Association Canadienne des Jeux Sous-Marins
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Hockey subaquatique
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Rugby subaquatique
-                    </a>
-                </span>
-            </p>
-        </div>
-        <div class="container mx-auto px-4">
-            <p>&copy; 2025 CUGA. Tous droits réservés.</p>
-            <p class="mt-4">
-                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">Code de Conduite CUGA</a> |
-                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
-            </p>
+    <footer id="footer-fr" class="site-footer-bar">
+        <!-- Note: Removed Tailwind classes like bg-gray-900, text-gray-400, py-8, text-center -->
+        <!-- The div.container.mx-auto.px-4 structure is slightly different from site-footer-bar's direct content model -->
+        <!-- For now, will keep internal structure and let site-footer-bar handle overall background/padding -->
+        <div class="footer-content-wrapper" style="width: 100%; display: flex; flex-direction: column; align-items: center;"> <!-- Helper for centering multi-line content -->
+            <div class="external-links py-2"> <!-- py-2 for some spacing, adjust as needed -->
+                 <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
+                    <span>
+                        <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
+                        <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer">Association Canadienne des Jeux Sous-Marins</a>
+                    </span>
+                    <span class="mx-2">|</span>
+                    <span>
+                        <i class="fa fa-globe text-green-200 mr-1"></i>
+                        <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer">CMAS Hockey subaquatique</a>
+                    </span>
+                    <span class="mx-2">|</span>
+                    <span>
+                        <i class="fa fa-globe text-green-200 mr-1"></i>
+                        <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer">CMAS Rugby subaquatique</a>
+                    </span>
+                </p>
+            </div>
+            <div class="footer-copyright">
+                &copy; <span id="currentYearFr">2025</span> CUGA. Tous droits réservés. <!-- Year will be updated by JS -->
+            </div>
+            <div class="footer-links">
+                <!-- Tailwind classes like text-blue-400 hover:underline removed, will rely on site-footer-bar a styles -->
+                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank">Code de Conduite CUGA</a>
+                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank">Règlements de la CUGA</a>
+                <a href="privacy-policy.html">Politique de Confidentialité</a>
+                <a href="terms-of-use.html">Conditions d'Utilisation</a>
+            </div>
         </div>
     </footer>
-    <footer id="footer-en" class="bg-gray-900 text-gray-400 py-8 text-center hidden">
-        <div class="container mx-auto px-4">
-            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                <span>
-                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
-                    <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CUGA (Canadian Underwater Games Association)
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Underwater Hockey
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Underwater Rugby
-                    </a>
-                </span>
-            </p>
-        </div>
-        <div class="container mx-auto px-4">
-            <p>&copy; 2025 CUGA. All rights reserved.</p>
-            <p class="mt-4">
-                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Code of Conduct</a> |
-                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>
+    <footer id="footer-en" class="site-footer-bar hidden">
+        <div class="footer-content-wrapper" style="width: 100%; display: flex; flex-direction: column; align-items: center;">
+            <div class="external-links py-2">
+                <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
+                    <span>
+                        <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
+                        <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer">CUGA (Canadian Underwater Games Association)</a>
+                    </span>
+                    <span class="mx-2">|</span>
+                    <span>
+                        <i class="fa fa-globe text-green-200 mr-1"></i>
+                        <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer">CMAS Underwater Hockey</a>
+                    </span>
+                    <span class="mx-2">|</span>
+                    <span>
+                        <i class="fa fa-globe text-green-200 mr-1"></i>
+                        <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer">CMAS Underwater Rugby</a>
+                    </span>
+                </p>
+            </div>
+            <div class="footer-copyright">
+                &copy; <span id="currentYearEn">2025</span> CUGA. All rights reserved. <!-- Year will be updated by JS -->
+            </div>
+            <div class="footer-links">
+                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank">CUGA Code of Conduct</a>
+                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank">CUGA Bylaws</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
+                <a href="terms-of-use.html">Terms of Use</a>
             </p>
         </div>
     </footer>
@@ -507,6 +515,14 @@
             const footerEn = document.getElementById('footer-en');
             const bannerFr = document.getElementById('lang-fr-banner');
             const bannerEn = document.getElementById('lang-en-banner');
+
+            // Update copyright year
+            const currentYear = new Date().getFullYear();
+            const currentYearFrSpan = document.getElementById('currentYearFr');
+            if (currentYearFrSpan) currentYearFrSpan.textContent = currentYear;
+            const currentYearEnSpan = document.getElementById('currentYearEn');
+            if (currentYearEnSpan) currentYearEnSpan.textContent = currentYear;
+
 
             const setLanguage = (lang) => {
                 currentLanguage = lang;

--- a/docs/financial-governance.html
+++ b/docs/financial-governance.html
@@ -3,10 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-en="Interactive Guide to Nonprofit Financial Governance" data-fr="Guide Interactif de Gouvernance Financière des Organismes à But Non Lucratif">Interactive Guide to Nonprofit Financial Governance</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <title data-en="Interactive Guide to Nonprofit Financial Governance" data-fr="Guide Interactif de Gouvernance Financière des Organismes à But Non Lucratif">Financial Governance - CUGA</title> <!-- Standardized Title a bit -->
+    <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../styles.css"> <!-- Link to global styles -->
+    <script src="https://cdn.tailwindcss.com"></script> <!-- Retain Tailwind for existing content -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <!-- Using Kumbh Sans from global styles, Inter link can be removed if not specifically needed by Tailwind components here -->
+    <!-- <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet"> -->
     <!-- Chosen Palette: Calm Harmony -->
     <!-- Application Structure Plan: A thematic, single-page dashboard designed for non-linear exploration. The structure uses a sticky top navigation to allow users to jump to key areas of concern: 1) Access Rights (the core question), 2) Legal Framework, 3) Restrictions, 4) Risks, and 5) Best Practices. This is more intuitive than the report's linear chapter format, allowing users to find answers to specific questions quickly. The core interaction revolves around an interactive diagram comparing Financial Statements vs. Accounting Records, clickable cards for detailed information, and a practical checklist. This structure prioritizes user-friendliness and quick comprehension of complex legal topics. -->
     <!-- Visualization & Content Choices:
@@ -62,31 +65,49 @@
         }
     </style>
 </head>
-<body class="antialiased">
+<body class="antialiased"> <!-- Retain antialiased if it's important for Tailwind's rendering here -->
 
-    <!-- Header & Navigation -->
-    <header class="bg-white/80 backdrop-blur-md sticky top-0 z-50 shadow-sm">
+    <!-- Standard CUGA Site Header -->
+    <header class="site-header">
+        <a href="../index.html" class="site-logo-link"> <!-- Adjusted path for index -->
+            <img src="../assets/logos/CUGA/Horizontal/EN/Reversed/CUGA-logo-h-en-reverse-rgb-sm.png" alt="CUGA Logo" class="site-logo">
+        </a>
+        <button class="hamburger-icon-button" id="hamburgerToggleButtonFinancial" aria-label="Open menu" aria-expanded="false" aria-controls="navMenuFinancial">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+    </header>
+
+    <!-- Full-screen Navigation Menu (from styles.css) -->
+    <nav class="nav-menu" id="navMenuFinancial" aria-hidden="true">
+        <!-- Site-wide links can be added here if needed, or this can be minimal if page-specific nav is primary -->
+        <a href="../index.html" class="nav-link">Home</a>
+        <a href="../cuga.html" class="nav-link">Clubs</a>
+        <!-- Add other global links as per other pages -->
+    </nav>
+
+    <!-- Secondary Navigation Bar for In-Page Links and Language Toggle -->
+    <div class="bg-white sticky top-0 z-40 shadow-sm py-2" style="margin-top: 0;"> <!-- Ensure it sits below the main header -->
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <div class="flex-shrink-0">
-                    <h1 class="text-xl md:text-2xl font-bold text-[#5D737E]" data-en="Nonprofit Governance Guide" data-fr="Guide de Gouvernance des Organismes à But Non Lucratif">Nonprofit Governance Guide</h1>
+            <div class="flex items-center justify-between h-12">
+                 <div class="flex-shrink-0">
+                    <h1 class="text-lg md:text-xl font-bold text-primary-color" data-en="Nonprofit Governance Guide" data-fr="Guide de Gouvernance des Organismes à But Non Lucratif">Nonprofit Governance Guide</h1>
                 </div>
-                <nav class="hidden md:block">
-                    <div class="ml-10 flex items-baseline space-x-4">
-                        <a href="#access-rights" class="nav-link px-3 py-2 text-sm font-medium" data-en="Access Rights" data-fr="Droits d'Accès">Access Rights</a>
-                        <a href="#legal-framework" class="nav-link px-3 py-2 text-sm font-medium" data-en="Legal Framework" data-fr="Cadre Légal">Legal Framework</a>
-                        <a href="#restrictions" class="nav-link px-3 py-2 text-sm font-medium" data-en="Restrictions" data-fr="Restrictions">Restrictions</a>
-                        <a href="#risks" class="nav-link px-3 py-2 text-sm font-medium" data-en="Risks" data-fr="Risques">Risks</a>
-                        <a href="#best-practices" class="nav-link px-3 py-2 text-sm font-medium" data-en="Best Practices" data-fr="Bonnes Pratiques">Best Practices</a>
-                    </div>
+                <nav class="hidden md:flex items-baseline space-x-3"> <!-- Reduced space a bit -->
+                    <a href="#access-rights" class="nav-link px-2 py-1 text-sm font-medium" data-en="Access Rights" data-fr="Droits d'Accès">Access Rights</a>
+                    <a href="#legal-framework" class="nav-link px-2 py-1 text-sm font-medium" data-en="Legal Framework" data-fr="Cadre Légal">Legal Framework</a>
+                    <a href="#restrictions" class="nav-link px-2 py-1 text-sm font-medium" data-en="Restrictions" data-fr="Restrictions">Restrictions</a>
+                    <a href="#risks" class="nav-link px-2 py-1 text-sm font-medium" data-en="Risks" data-fr="Risques">Risks</a>
+                    <a href="#best-practices" class="nav-link px-2 py-1 text-sm font-medium" data-en="Best Practices" data-fr="Bonnes Pratiques">Best Practices</a>
                 </nav>
                 <div class="flex items-center space-x-4">
-                    <select id="language-select" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-[#5D737E] focus:border-[#5D737E] block p-2.5">
+                    <select id="language-select" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-secondary-color focus:border-secondary-color block p-2"> <!-- Adjusted focus colors -->
                         <option value="en">English</option>
                         <option value="fr">Français</option>
                     </select>
-                    <div class="md:hidden">
-                        <select id="mobile-nav" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-[#5D737E] focus:border-[#5D737E] block w-full p-2.5">
+                    <div class="md:hidden"> <!-- Mobile dropdown for in-page nav -->
+                        <select id="mobile-nav" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-secondary-color focus:border-secondary-color block w-full p-2">
                             <option value="#access-rights" data-en="Access Rights" data-fr="Droits d'Accès">Access Rights</option>
                             <option value="#legal-framework" data-en="Legal Framework" data-fr="Cadre Légal">Legal Framework</option>
                             <option value="#restrictions" data-en="Restrictions" data-fr="Restrictions">Restrictions</option>
@@ -97,7 +118,7 @@
                 </div>
             </div>
         </div>
-    </header>
+    </div>
 
     <main class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
 
@@ -246,10 +267,19 @@
         </section>
     </main>
 
-    <footer class="bg-gray-800 text-white mt-20">
-        <div class="container mx-auto py-6 px-4 text-center text-sm">
-            <p data-en="Generated by Gemini Deep Research, June 2025" data-fr="Généré par Gemini Deep Research, juin 2025">Generated by Gemini Deep Research, June 2025</p>
-            <p class="mt-2 text-gray-400" data-en="Please note: This interactive guide is for informational purposes only and does not constitute legal advice. Nonprofits should consult with qualified legal and accounting professionals." data-fr="Veuillez noter: Ce guide interactif est à titre informatif seulement et ne constitue pas un avis juridique. Les organismes à but non lucratif devraient consulter des professionnels du droit et de la comptabilité qualifiés.">Please note: This interactive guide is for informational purposes only and does not constitute legal advice. Nonprofits should consult with qualified legal and accounting professionals.</p>
+    <footer class="site-footer-bar">
+        <!-- Original content from this page's footer -->
+        <div class="footer-content-wrapper text-center" style="width: 100%; font-size: 0.8rem; padding: 0.5rem 0;"> <!-- Added text-center and some padding -->
+            <p data-en="Generated by Gemini Deep Research, June 2025" data-fr="Généré par Gemini Deep Research, juin 2025" style="margin-bottom: 0.25rem;">Generated by Gemini Deep Research, June 2025</p>
+            <p data-en="Please note: This interactive guide is for informational purposes only and does not constitute legal advice. Nonprofits should consult with qualified legal and accounting professionals." data-fr="Veuillez noter: Ce guide interactif est à titre informatif seulement et ne constitue pas un avis juridique. Les organismes à but non lucratif devraient consulter des professionnels du droit et de la comptabilité qualifiés." style="margin-bottom: 0.5rem;">Please note: This interactive guide is for informational purposes only and does not constitute legal advice. Nonprofits should consult with qualified legal and accounting professionals.</p>
+        </div>
+        <!-- Standard CUGA Footer Content -->
+        <div class="footer-copyright">
+            Copyright &copy;<span id="currentYearFinancialGov"></span> CUGA.CA
+        </div>
+        <div class="footer-links">
+            <a href="../terms-of-use.html">Terms & Conditions</a> <!-- Adjusted path -->
+            <a href="../privacy-policy.html">Privacy Policy</a> <!-- Adjusted path -->
         </div>
     </footer>
 
@@ -641,6 +671,47 @@
             // Initial content update and checklist rendering
             updateContent();
         });
+    </script>
+    <script>
+        // Hamburger Menu for Financial Governance Page
+        const hamburgerToggleFinancial = document.getElementById('hamburgerToggleButtonFinancial');
+        const navMenuFinancial = document.getElementById('navMenuFinancial');
+
+        if (hamburgerToggleFinancial && navMenuFinancial) {
+            hamburgerToggleFinancial.addEventListener('click', () => {
+                const isOpen = navMenuFinancial.classList.toggle('is-open');
+                hamburgerToggleFinancial.setAttribute('aria-expanded', isOpen);
+                navMenuFinancial.setAttribute('aria-hidden', !isOpen);
+            });
+
+            // Close menu with Escape key
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && navMenuFinancial.classList.contains('is-open')) {
+                    navMenuFinancial.classList.remove('is-open');
+                    hamburgerToggleFinancial.setAttribute('aria-expanded', 'false');
+                    navMenuFinancial.setAttribute('aria-hidden', 'true');
+                    hamburgerToggleFinancial.focus();
+                }
+            });
+
+            // Close menu when a nav link is clicked
+            navMenuFinancial.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', () => {
+                    if (navMenuFinancial.classList.contains('is-open')) {
+                        navMenuFinancial.classList.remove('is-open');
+                        hamburgerToggleFinancial.setAttribute('aria-expanded', 'false');
+                        navMenuFinancial.setAttribute('aria-hidden', 'true');
+                        hamburgerToggleFinancial.focus();
+                    }
+                });
+            });
+        }
+
+        // Dynamic year in footer for Financial Governance Page
+        const currentYearSpanFinancialGov = document.getElementById("currentYearFinancialGov");
+        if (currentYearSpanFinancialGov) {
+            currentYearSpanFinancialGov.textContent = new Date().getFullYear();
+        }
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="fr"> <!-- Default lang, JS will manage -->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CUGA - Canadian Underwater Games Association | Underwater Sports</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.tailwindcss.com"></script> <!-- Retaining Tailwind for existing content -->
     <link rel="stylesheet" href="assets/fontawesome/css/font-awesome.min.css">
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <link rel="preload" as="image" href="images/hockey.jpg">
@@ -33,14 +35,14 @@
     <meta name="twitter:image" content="images/hockey.jpg">
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <style>
-        body {
-            font-family: 'Inter', sans-serif;
-        }
+        /* body { */
+            /* font-family: 'Inter', sans-serif; */ /* Replaced by Kumbh Sans from styles.css */
+        /* } */
         /* French content shown by default (as per html[lang=fr]). English content hidden initially. JS manages language switching. */
         .lang-en {
             display: none; /* Hide English content by default to prevent flash and provide a no-JS fallback */
         }
-        .active-nav-link {
+        .active-nav-link { /* For the custom side-nav */
             color: #FACC15; /* Corresponds to Tailwind's yellow-400 */
             font-weight: bold;
         }
@@ -95,10 +97,43 @@
         }
     </style>
 </head>
-<body class="bg-blue-700 text-white">
-    <div class="bubbles">
+<body class="text-white"> <!-- Removed bg-blue-700, styles.css will provide body background. Retained text-white as much of the direct body content might expect it. -->
+    <!-- Standard CUGA Site Header -->
+    <header class="site-header">
+        <a href="index.html" class="site-logo-link">
+            <!-- Logo initially set to FR, JS will update based on language -->
+            <img id="globalCugaLogo" src="assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png" alt="CUGA Logo" class="site-logo">
+        </a>
+        <button class="hamburger-icon-button" id="hamburgerToggleButtonIndex" aria-label="Open menu" aria-expanded="false" aria-controls="navMenuIndex">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+    </header>
+
+    <!-- Full-screen Navigation Menu (from styles.css) -->
+    <nav class="nav-menu" id="navMenuIndex" aria-hidden="true">
+        <a href="index.html" class="nav-link active">Home</a>
+        <a href="cuga.html" class="nav-link">Clubs</a>
+        <a href="join.html" class="nav-link">Join CUGA</a>
+        <a href="#about-us-fr" class="nav-link lang-fr-nav-item" data-target-id="about-us-fr">À propos</a> <!-- In-page link for FR -->
+        <a href="#executive-fr" class="nav-link lang-fr-nav-item" data-target-id="executive-fr">Exécutif</a> <!-- In-page link for FR -->
+        <a href="#sports" class="nav-link lang-fr-nav-item" data-target-id="sports">Disciplines</a> <!-- In-page link for FR -->
+        <a href="#nationals" class="nav-link lang-fr-nav-item" data-target-id="nationals">Championnats</a> <!-- In-page link for FR -->
+        <a href="#contact" class="nav-link lang-fr-nav-item" data-target-id="contact">Contact</a> <!-- In-page link for FR -->
+        <a href="#about-us-en" class="nav-link lang-en-nav-item" data-target-id="about-us-en" style="display:none;">About Us</a> <!-- In-page link for EN -->
+        <a href="#executive-en" class="nav-link lang-en-nav-item" data-target-id="executive-en" style="display:none;">Executive</a> <!-- In-page link for EN -->
+        <a href="#sports-en" class="nav-link lang-en-nav-item" data-target-id="sports-en" style="display:none;">Disciplines</a> <!-- In-page link for EN -->
+        <a href="#nationals-en" class="nav-link lang-en-nav-item" data-target-id="nationals-en" style="display:none;">Nationals</a> <!-- In-page link for EN -->
+        <a href="#contact-en" class="nav-link lang-en-nav-item" data-target-id="contact-en" style="display:none;">Contact</a> <!-- In-page link for EN -->
+        <a href="docs/financial-governance.html" class="nav-link">Financial Governance</a>
+        <!-- Other global links: terms-of-use.html, privacy-policy.html will be in footer -->
+    </nav>
+
+    <div class="bubbles"> <!-- Retained bubbles -->
     </div>
 
+    <!-- Side navigation (retained, with lang-fr/lang-en classes for JS toggle) -->
     <nav class="lang-fr fixed top-1/2 right-4 transform -translate-y-1/2 bg-opacity-75 bg-blue-800 text-white p-3 rounded-lg z-50 shadow-md hidden lg:block force-hide-mobile">
         <ul class="flex flex-col space-y-2">
             <li class="py-1"><a href="join.html" class="hover:text-yellow-300">Rejoindre CUGA</a></li>
@@ -110,7 +145,7 @@
         </ul>
     </nav>
 
-    <nav class="lang-en fixed top-1/2 right-4 transform -translate-y-1/2 bg-opacity-75 bg-blue-800 text-white p-3 rounded-lg z-50 shadow-md hidden lg:block force-hide-mobile">
+    <nav class="lang-en fixed top-1/2 right-4 transform -translate-y-1/2 bg-opacity-75 bg-blue-800 text-white p-3 rounded-lg z-50 shadow-md hidden lg:block force-hide-mobile" style="display:none;"> <!-- Initially hidden if FR is default -->
         <ul class="flex flex-col space-y-2">
             <li class="py-1"><a href="join.html" class="hover:text-yellow-300">Join CUGA</a></li>
             <li class="py-1"><a href="#about-us-en" class="hover:text-yellow-300">About Us</a></li>
@@ -121,6 +156,7 @@
         </ul>
     </nav>
 
+    <!-- Language Toggle Buttons and Experimental Banner (retained) -->
     <div class="text-center py-4 bg-gray-200">
         <button class="lang-button px-4 py-2 mr-2 rounded bg-blue-500 text-white" data-lang="fr">
             <i class="fa fa-fleur-de-lis"></i> Français
@@ -136,12 +172,15 @@
         Ceci est un site web expérimental pour CUGA. Le site officiel de CUGA se trouve à <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-700">https://cuga.org/</a>.
     </div>
 
+    <!-- Page specific title/subtitle, to be shown/hidden by JS lang toggle -->
+    <div id="pageSubtitleContainer" class="text-center py-4" style="background-color: var(--primary-color); color: var(--white);">
+        <p id="cugaSubtitleDisplay" class="text-md md:text-lg italic"></p>
+        <p id="cugaTaglineDisplay" class="mt-1 text-md md:text-lg italic"></p>
+    </div>
+
+    <!-- Original lang-fr and lang-en content wrappers remain for JS toggling -->
     <div class="lang-fr">
-        <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-            <img src="assets/logos/CUGA/Horizontal/FR/FullColor/CUGA-logo-h-fr-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto">
-            <p class="mt-1 text-md md:text-lg italic">Association Canadienne des Jeux Subaquatiques</p>
-            <p class="mt-1 text-md md:text-lg italic">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p>
-        </header>
+        <!-- FR Header removed, content starts from main -->
         <main>
         <section id="sports" class="container mx-auto px-4 py-16" data-aos="fade-up">
             <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">Découvrez Nos Disciplines</h2>
@@ -283,49 +322,11 @@
         </section>
 
         </main>
-    <footer id="footer-fr" class="bg-gray-900 text-gray-400 py-8 text-center">
-        <div class="container mx-auto px-4">
-            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                <span>
-                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
-                    <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        Association Canadienne des Jeux Sous-Marins
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Hockey subaquatique
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Rugby subaquatique
-                    </a>
-                </span>
-            </p>
-        </div>
-        <div class="container mx-auto px-4">
-            <p>&copy; 2025 CUGA. Tous droits réservés.</p>
-            <p class="mt-4">
-                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">Code de Conduite CUGA</a> |
-                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
-            </p>
-        </div>
-    </footer>
+    <!-- French Footer Removed -->
     </div>
 
     <div class="lang-en">
-        <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-            <img src="assets/logos/CUGA/Horizontal/EN/FullColor/CUGA-logo-h-en-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto">
-            <p class="mt-1 text-md md:text-lg italic">Canadian Underwater Games Association</p>
-            <p class="mt-1 text-md md:text-lg italic">Dive into the action with Underwater Hockey and Underwater Rugby!</p>
-        </header>
+        <!-- English Header removed -->
         <main>
         <section id="sports-en" class="container mx-auto px-4 py-16" data-aos="fade-up">
             <h2 class="text-3xl md:text-4xl font-semibold text-center mb-12 text-gray-800">Discover Our Disciplines</h2>
@@ -468,53 +469,110 @@
         </section>
 
         </main>
-    <footer id="footer-en" class="bg-gray-900 text-gray-400 py-8 text-center">
-        <div class="container mx-auto px-4">
-            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                <span>
-                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
-                    <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CUGA (Canadian Underwater Games Association)
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Underwater Hockey
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Underwater Rugby
-                    </a>
-                </span>
-            </p>
-        </div>
-        <div class="container mx-auto px-4">
-            <p>&copy; 2025 CUGA. All rights reserved.</p>
-            <p class="mt-4">
-                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Code of Conduct</a> |
-                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>
-            </p>
-        </div>
-    </footer>
+    <!-- English Footer Removed -->
     </div>
 
+    <!-- Global Site Footer Bar (replaces individual lang footers) -->
+    <footer class="site-footer-bar">
+        <div class="footer-copyright">
+            Copyright &copy;<span id="currentYearIndex"></span> CUGA.CA
+        </div>
+        <div class="footer-links">
+            <!-- JS will populate these based on language -->
+            <span id="footerLinksDynamic">
+                <!-- Placeholder for language specific links like cuga.org, cmas -->
+            </span>
+            <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="lang-fr-footer-item">Code de Conduite CUGA</a>
+            <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="lang-fr-footer-item">Règlements de la CUGA</a>
+            <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="lang-en-footer-item" style="display:none;">CUGA Code of Conduct</a>
+            <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="lang-en-footer-item" style="display:none;">CUGA Bylaws</a>
+            <a href="privacy-policy.html">Privacy Policy</a> <!-- Common for both languages -->
+            <a href="terms-of-use.html">Terms of Use</a> <!-- Common for both languages -->
+        </div>
+    </footer>
+
+    <script>
+    // Hamburger Menu for Index Page
+    const hamburgerToggleIndex = document.getElementById('hamburgerToggleButtonIndex');
+    const navMenuIndex = document.getElementById('navMenuIndex');
+
+    if (hamburgerToggleIndex && navMenuIndex) {
+        hamburgerToggleIndex.addEventListener('click', () => {
+            const isOpen = navMenuIndex.classList.toggle('is-open');
+            hamburgerToggleIndex.setAttribute('aria-expanded', isOpen);
+            navMenuIndex.setAttribute('aria-hidden', !isOpen);
+        });
+
+        // Close menu with Escape key
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && navMenuIndex.classList.contains('is-open')) {
+                navMenuIndex.classList.remove('is-open');
+                hamburgerToggleIndex.setAttribute('aria-expanded', 'false');
+                navMenuIndex.setAttribute('aria-hidden', 'true');
+                hamburgerToggleIndex.focus();
+            }
+        });
+
+        // Close menu when a nav link is clicked (including in-page hash links)
+        navMenuIndex.querySelectorAll('.nav-link').forEach(link => {
+            link.addEventListener('click', () => {
+                if (navMenuIndex.classList.contains('is-open')) {
+                    navMenuIndex.classList.remove('is-open');
+                    hamburgerToggleIndex.setAttribute('aria-expanded', 'false');
+                    navMenuIndex.setAttribute('aria-hidden', 'true');
+                    hamburgerToggleIndex.focus();
+
+                    // Handle smooth scroll for hash links if the menu was open
+                    const targetId = link.dataset.targetId;
+                    if (targetId) {
+                        const targetElement = document.getElementById(targetId);
+                        if (targetElement) {
+                           setTimeout(() => { // Timeout to allow menu to close before scrolling
+                            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                           }, 100);
+                        }
+                    }
+                } else {
+                    // If menu is already closed and it's a hash link, just scroll
+                    const targetId = link.dataset.targetId;
+                     if (targetId) {
+                        const targetElement = document.getElementById(targetId);
+                        if (targetElement) {
+                            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        }
+                    }
+                }
+            });
+        });
+    }
+
+    // Dynamic year in footer for Index Page
+    const currentYearSpanIndex = document.getElementById("currentYearIndex");
+    if (currentYearSpanIndex) {
+        currentYearSpanIndex.textContent = new Date().getFullYear();
+    }
+    </script>
     <script>
   document.addEventListener('DOMContentLoaded', function() {
     function appendVersionInfoToFooters(element) {
-      const selectors = ['.lang-fr footer .container:last-of-type', '.lang-en footer .container:last-of-type'];
-      selectors.forEach(selector => {
-        const footerContainer = document.querySelector(selector);
-        if (footerContainer) {
-          footerContainer.appendChild(element.cloneNode(true));
-        }
-      });
+      // const selectors = ['.lang-fr footer .container:last-of-type', '.lang-en footer .container:last-of-type'];
+      // selectors.forEach(selector => {
+      //   const footerContainer = document.querySelector(selector);
+      //   if (footerContainer) {
+      //     footerContainer.appendChild(element.cloneNode(true));
+      //   }
+      // });
+      // New logic: append to the single global footer
+      const globalFooter = document.querySelector('.site-footer-bar');
+      if (globalFooter) {
+          // Create a new div for version info to be appended after footer-links
+          const versionDiv = document.createElement('div');
+          versionDiv.style.textAlign = 'center'; // Center the text
+          versionDiv.style.width = '100%';      // Ensure it takes full width for centering
+          versionDiv.style.marginTop = '0.5rem'; // Add some space above
+          versionDiv.appendChild(element);
+          globalFooter.appendChild(versionDiv);
+      }
     }
 
     function createVersionElement(text, isError) {
@@ -562,18 +620,74 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const langButtons = document.querySelectorAll('.lang-button');
-            const langSections = document.querySelectorAll('.lang-fr, .lang-en');
+            const langFrSections = document.querySelectorAll('.lang-fr'); // More specific selector for content
+            const langEnSections = document.querySelectorAll('.lang-en'); // More specific selector for content
+            const globalLogo = document.getElementById('globalCugaLogo');
+            const subtitleDisplay = document.getElementById('cugaSubtitleDisplay');
+            const taglineDisplay = document.getElementById('cugaTaglineDisplay');
+            const navMenu = document.getElementById('navMenuIndex');
+            const footerLinksDynamic = document.getElementById('footerLinksDynamic');
+
+
+            const siteContent = { // Store language-specific content
+                fr: {
+                    logo: "assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png",
+                    subtitle: "Association Canadienne des Jeux Subaquatiques",
+                    tagline: "Plongez dans l'action avec le Hockey et le Rugby Subaquatique !",
+                    footerHtml: `
+                        <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer">Association Canadienne des Jeux Sous-Marins</a>
+                        <span class="mx-1">|</span>
+                        <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer">CMAS Hockey subaquatique</a>
+                        <span class="mx-1">|</span>
+                        <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer">CMAS Rugby subaquatique</a>
+                    `
+                },
+                en: {
+                    logo: "assets/logos/CUGA/Horizontal/EN/Reversed/CUGA-logo-h-en-reverse-rgb-sm.png",
+                    subtitle: "Canadian Underwater Games Association",
+                    tagline: "Dive into the action with Underwater Hockey and Underwater Rugby!",
+                    footerHtml: `
+                        <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer">CUGA (Canadian Underwater Games Association)</a>
+                        <span class="mx-1">|</span>
+                        <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer">CMAS Underwater Hockey</a>
+                        <span class="mx-1">|</span>
+                        <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer">CMAS Underwater Rugby</a>
+                    `
+                }
+            };
 
             const setLanguage = (lang) => {
-                langSections.forEach(section => {
-                    section.style.display = section.classList.contains(`lang-${lang}`) ? 'block' : 'none';
-                });
+                // Toggle main content sections (FR/EN divs)
+                langFrSections.forEach(section => section.style.display = (lang === 'fr') ? 'block' : 'none');
+                langEnSections.forEach(section => section.style.display = (lang === 'en') ? 'block' : 'none');
+
+                // Update global header logo and subtitle/tagline
+                if (globalLogo) globalLogo.src = siteContent[lang].logo;
+                if (subtitleDisplay) subtitleDisplay.textContent = siteContent[lang].subtitle;
+                if (taglineDisplay) taglineDisplay.textContent = siteContent[lang].tagline;
+
+                // Update language toggle buttons
                 langButtons.forEach(button => {
-                    button.classList.toggle('bg-blue-600', button.dataset.lang === lang);
+                    button.classList.toggle('bg-blue-600', button.dataset.lang === lang); // Assuming new primary color
                     button.classList.toggle('text-white', button.dataset.lang === lang);
                     button.classList.toggle('bg-gray-400', button.dataset.lang !== lang);
                     button.classList.toggle('text-gray-800', button.dataset.lang !== lang);
                 });
+
+                // Update main nav menu links visibility
+                if (navMenu) {
+                    navMenu.querySelectorAll('.lang-fr-nav-item').forEach(item => item.style.display = (lang === 'fr') ? 'block' : 'none');
+                    navMenu.querySelectorAll('.lang-en-nav-item').forEach(item => item.style.display = (lang === 'en') ? 'block' : 'none');
+                }
+
+                // Update footer links
+                if (footerLinksDynamic) {
+                    footerLinksDynamic.innerHTML = siteContent[lang].footerHtml;
+                }
+                document.querySelectorAll('.lang-fr-footer-item').forEach(item => item.style.display = (lang === 'fr') ? 'inline' : 'none');
+                document.querySelectorAll('.lang-en-footer-item').forEach(item => item.style.display = (lang === 'en') ? 'inline' : 'none');
+
+
                 document.documentElement.lang = lang;
                 localStorage.setItem('language', lang); // Store language choice
             };

--- a/join.html
+++ b/join.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Adhésion CUGA / CUGA Membership - Association Canadienne des Jeux Subaquatiques</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.tailwindcss.com"></script> <!-- Retain Tailwind -->
     <link rel="stylesheet" href="assets/fontawesome/css/font-awesome.min.css">
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <!-- Google tag (gtag.js) -->
@@ -19,16 +21,36 @@
     <meta name="description" content="Rejoignez CUGA et devenez membre de la communauté canadienne des sports subaquatiques. Apprenez-en plus sur l'adhésion, les frais et les avantages. Join CUGA and become a part of the Canadian underwater sports community. Learn about membership, fees, and benefits.">
     <meta name="keywords" content="CUGA, rejoindre CUGA, adhésion CUGA, sports subaquatiques, Canada, hockey subaquatique, rugby subaquatique, Association Canadienne des Jeux Subaquatiques, join CUGA, underwater sports, membership">
     <style>
-        body {
-            font-family: 'Inter', sans-serif;
-        }
+        /* body { font-family: 'Inter', sans-serif; } */ /* Replaced by Kumbh Sans */
         /* French content shown by default (as per html[lang=fr]). English content hidden initially. JS manages language switching. */
         .lang-en {
             display: none; /* Hide English content by default */
         }
     </style>
 </head>
-<body class="bg-blue-700 text-white">
+<body class="text-white"> <!-- Removed bg-blue-700 from body, styles.css will handle body bg -->
+    <!-- Standard CUGA Site Header -->
+    <header class="site-header">
+        <a href="index.html" class="site-logo-link">
+            <img id="globalCugaLogoJoin" src="assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png" alt="CUGA Logo" class="site-logo"> <!-- Default to FR -->
+        </a>
+        <button class="hamburger-icon-button" id="hamburgerToggleButtonJoin" aria-label="Open menu" aria-expanded="false" aria-controls="navMenuJoin">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+    </header>
+
+    <!-- Full-screen Navigation Menu -->
+    <nav class="nav-menu" id="navMenuJoin" aria-hidden="true">
+        <a href="index.html" class="nav-link">Home</a>
+        <a href="cuga.html" class="nav-link">Clubs</a>
+        <a href="join.html" class="nav-link active">Join CUGA</a>
+        <a href="docs/financial-governance.html" class="nav-link">Financial Governance</a>
+        <!-- Links for terms, privacy will be in footer -->
+    </nav>
+
+    <!-- Language Toggle Buttons and Experimental Banner (retained) -->
     <div class="text-center py-4 bg-gray-200">
         <button class="lang-button px-4 py-2 mr-2 rounded bg-blue-500 text-white" data-lang="fr">
             <i class="fa fa-fleur-de-lis"></i> Français
@@ -44,16 +66,11 @@
         Ceci est un site web expérimental pour CUGA. Le site officiel de CUGA se trouve à <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-700">https://cuga.org/</a>.
     </div>
 
-    <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-        <img src="assets/logos/CUGA/Horizontal/EN/FullColor/CUGA-logo-h-en-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto"> <!-- Universal Logo -->
-        <div class="lang-fr">
-            <p class="mt-1 text-md md:text-lg italic">Adhésion à CUGA</p>
-        </div>
-        <div class="lang-en" style="display: none;">
-            <p class="mt-1 text-md md:text-lg italic">CUGA Membership</p>
-        </div>
-    </header>
-
+    <!-- Page specific title/subtitle, to be shown/hidden by JS lang toggle -->
+    <div id="pageSubtitleContainerJoin" class="text-center py-4" style="background-color: var(--primary-color); color: var(--white);">
+        <p id="joinPageSubtitle" class="text-xl md:text-2xl font-bold"></p> <!-- Adjusted class for prominence -->
+    </div>
+    <!-- Old header was here, it's removed by the previous step where the new header was added and this section was part of the SEARCH block -->
     <main class="container mx-auto px-4 py-16">
         <!-- English Content -->
         <div class="lang-en bg-white text-gray-800 rounded-xl shadow-xl p-8 md:p-12">
@@ -212,79 +229,66 @@
         </div>
     </main>
 
-    <footer id="footer-fr" class="bg-gray-900 text-gray-400 py-8 text-center lang-fr">
-        <div class="container mx-auto px-4">
-            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                <span>
-                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
-                    <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        Association Canadienne des Jeux Sous-Marins
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Hockey subaquatique
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Rugby subaquatique
-                    </a>
-                </span>
-            </p>
+    <!-- Global Site Footer Bar (replaces individual lang footers) -->
+    <footer class="site-footer-bar">
+        <div class="footer-copyright">
+            Copyright &copy;<span id="currentYearJoin"></span> CUGA.CA
         </div>
-        <div class="container mx-auto px-4">
-            <p>&copy; 2025 CUGA. Tous droits réservés.</p>
-            <p class="mt-4">
-                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">Code de Conduite CUGA</a> |
-                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">Règlements de la CUGA</a> |
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Politique de Confidentialité</a> |
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Conditions d'Utilisation</a>
-            </p>
-        </div>
-    </footer>
-    <footer id="footer-en" class="bg-gray-900 text-gray-400 py-8 text-center lang-en">
-        <div class="container mx-auto px-4">
-            <p class="mt-2 flex flex-wrap justify-center gap-2 items-center">
-                <span>
-                    <i class="fa fa-canadian-maple-leaf text-red-500 mr-1"></i>
-                    <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CUGA (Canadian Underwater Games Association)
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Underwater Hockey
-                    </a>
-                </span>
-                <span class="mx-2">|</span>
-                <span>
-                    <i class="fa fa-globe text-green-200 mr-1"></i>
-                    <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer" class="underline text-blue-200 hover:text-white font-semibold">
-                        CMAS Underwater Rugby
-                    </a>
-                </span>
-            </p>
-        </div>
-        <div class="container mx-auto px-4">
-            <p>&copy; 2025 CUGA. All rights reserved.</p>
-            <p class="mt-4">
-                <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Code of Conduct</a> |
-                <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="text-blue-400 hover:underline">CUGA Bylaws</a> |
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline">Privacy Policy</a> |
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline">Terms of Use</a>
-            </p>
+        <div class="footer-links">
+            <!-- JS will populate these based on language -->
+            <span id="footerLinksDynamicJoin">
+                <!-- Placeholder for language specific links like cuga.org, cmas -->
+            </span>
+            <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="lang-fr-footer-item">Code de Conduite CUGA</a>
+            <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="lang-fr-footer-item">Règlements de la CUGA</a>
+            <a href="docs/CUGA%20Code%20of%20Conduct%20(June%202022).pdf" target="_blank" class="lang-en-footer-item" style="display:none;">CUGA Code of Conduct</a>
+            <a href="docs/CUGA%20Constitution%20%26%20By-laws%20(2024).pdf" target="_blank" class="lang-en-footer-item" style="display:none;">CUGA Bylaws</a>
+            <a href="privacy-policy.html">Privacy Policy</a> <!-- Common for both languages -->
+            <a href="terms-of-use.html">Terms of Use</a> <!-- Common for both languages -->
         </div>
     </footer>
 
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
+        // Hamburger Menu for Join Page
+        const hamburgerToggleJoin = document.getElementById('hamburgerToggleButtonJoin');
+        const navMenuJoin = document.getElementById('navMenuJoin');
+
+        if (hamburgerToggleJoin && navMenuJoin) {
+            hamburgerToggleJoin.addEventListener('click', () => {
+                const isOpen = navMenuJoin.classList.toggle('is-open');
+                hamburgerToggleJoin.setAttribute('aria-expanded', isOpen);
+                navMenuJoin.setAttribute('aria-hidden', !isOpen);
+            });
+             // Close menu with Escape key
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && navMenuJoin.classList.contains('is-open')) {
+                    navMenuJoin.classList.remove('is-open');
+                    hamburgerToggleJoin.setAttribute('aria-expanded', 'false');
+                    navMenuJoin.setAttribute('aria-hidden', 'true');
+                    hamburgerToggleJoin.focus();
+                }
+            });
+            // Close menu when a nav link is clicked
+            navMenuJoin.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', () => {
+                    if (navMenuJoin.classList.contains('is-open')) {
+                        navMenuJoin.classList.remove('is-open');
+                        hamburgerToggleJoin.setAttribute('aria-expanded', 'false');
+                        navMenuJoin.setAttribute('aria-hidden', 'true');
+                        hamburgerToggleJoin.focus();
+                    }
+                });
+            });
+        }
+
+        // Dynamic year in footer for Join Page
+        const currentYearSpanJoin = document.getElementById("currentYearJoin");
+        if (currentYearSpanJoin) {
+            currentYearSpanJoin.textContent = new Date().getFullYear();
+        }
+
+        // AOS and Language Switching Logic
         document.addEventListener('DOMContentLoaded', () => {
             AOS.init({
                 duration: 1000,
@@ -292,29 +296,64 @@
             });
 
             const langButtons = document.querySelectorAll('.lang-button');
-            const langSections = document.querySelectorAll('.lang-fr, .lang-en'); // Affects all elements with these classes
+            const langFrPageContent = document.querySelectorAll('main > .lang-fr'); // Content within main
+            const langEnPageContent = document.querySelectorAll('main > .lang-en'); // Content within main
+            const globalLogoJoin = document.getElementById('globalCugaLogoJoin');
+            const joinPageSubtitle = document.getElementById('joinPageSubtitle');
+            const footerLinksDynamicJoin = document.getElementById('footerLinksDynamicJoin');
+
+            const pageSpecificContent = {
+                fr: {
+                    logo: "assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png",
+                    subtitle: "Adhésion à CUGA",
+                    footerHtml: `
+                        <a href="https://cuga.org/fr/" target="_blank" rel="noopener noreferrer">Association Canadienne des Jeux Sous-Marins</a>
+                        <span class="mx-1">|</span>
+                        <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer">CMAS Hockey subaquatique</a>
+                        <span class="mx-1">|</span>
+                        <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer">CMAS Rugby subaquatique</a>
+                    `
+                },
+                en: {
+                    logo: "assets/logos/CUGA/Horizontal/EN/Reversed/CUGA-logo-h-en-reverse-rgb-sm.png",
+                    subtitle: "CUGA Membership",
+                    footerHtml: `
+                        <a href="https://cuga.org/en/" target="_blank" rel="noopener noreferrer">CUGA (Canadian Underwater Games Association)</a>
+                        <span class="mx-1">|</span>
+                        <a href="https://www.cmas.org/hockey/latest.html" target="_blank" rel="noopener noreferrer">CMAS Underwater Hockey</a>
+                        <span class="mx-1">|</span>
+                        <a href="https://www.cmas.org/rugby/latest.html" target="_blank" rel="noopener noreferrer">CMAS Underwater Rugby</a>
+                    `
+                }
+            };
 
             const setLanguage = (lang) => {
-                // Update HTML lang attribute
                 document.documentElement.lang = lang;
 
-                // Show/hide sections based on selected language
-                langSections.forEach(section => {
-                    if (section.classList.contains(`lang-${lang}`)) {
-                        section.style.display = 'block'; // Or 'flex', 'grid', etc., depending on element type
-                    } else {
-                        section.style.display = 'none';
-                    }
-                });
+                // Toggle main page content sections
+                langFrPageContent.forEach(el => el.style.display = (lang === 'fr') ? 'block' : 'none');
+                langEnPageContent.forEach(el => el.style.display = (lang === 'en') ? 'block' : 'none');
 
-                // Update button styles
+                // Update global header logo and page subtitle
+                if (globalLogoJoin) globalLogoJoin.src = pageSpecificContent[lang].logo;
+                if (joinPageSubtitle) joinPageSubtitle.textContent = pageSpecificContent[lang].subtitle;
+
+                // Update language toggle buttons
                 langButtons.forEach(button => {
-                    button.classList.toggle('bg-blue-600', button.dataset.lang === lang); // Active language button
+                    button.classList.toggle('bg-blue-600', button.dataset.lang === lang);
                     button.classList.toggle('text-white', button.dataset.lang === lang);
-                    button.classList.toggle('bg-gray-400', button.dataset.lang !== lang); // Inactive language button
+                    button.classList.toggle('bg-gray-400', button.dataset.lang !== lang);
                     button.classList.toggle('text-gray-800', button.dataset.lang !== lang);
                 });
-                localStorage.setItem('language', lang); // Store language choice
+
+                // Update footer links
+                if (footerLinksDynamicJoin) {
+                    footerLinksDynamicJoin.innerHTML = pageSpecificContent[lang].footerHtml;
+                }
+                document.querySelectorAll('.lang-fr-footer-item').forEach(item => item.style.display = (lang === 'fr') ? 'inline' : 'none');
+                document.querySelectorAll('.lang-en-footer-item').forEach(item => item.style.display = (lang === 'en') ? 'inline' : 'none');
+
+                localStorage.setItem('language', lang);
             };
 
             // Language initialization logic

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,24 +3,47 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Politique de Confidentialité | Privacy Policy</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <title>Politique de Confidentialité | Privacy Policy - CUGA</title>
+    <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.tailwindcss.com"></script> <!-- Retain Tailwind for now, for buttons and basic layout if needed -->
     <style>
-        body {
-            font-family: 'Inter', sans-serif;
-        }
+        /* body { font-family: 'Inter', sans-serif; } */ /* Replaced by Kumbh Sans */
         .lang-en {
             display: none;
         }
     </style>
 </head>
-<body class="bg-gray-100 text-gray-800">
-    <div class="text-center py-4 bg-gray-200">
+<body> <!-- Removed Tailwind bg-gray-100, text-gray-800. styles.css will handle body bg and text color -->
+    <!-- Standard CUGA Site Header -->
+    <header class="site-header">
+        <a href="index.html" class="site-logo-link">
+            <img id="globalCugaLogoPP" src="assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png" alt="CUGA Logo" class="site-logo">
+        </a>
+        <button class="hamburger-icon-button" id="hamburgerToggleButtonPP" aria-label="Open menu" aria-expanded="false" aria-controls="navMenuPP">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+    </header>
+
+    <!-- Full-screen Navigation Menu -->
+    <nav class="nav-menu" id="navMenuPP" aria-hidden="true">
+        <a href="index.html" class="nav-link">Home</a>
+        <a href="cuga.html" class="nav-link">Clubs</a>
+        <a href="join.html" class="nav-link">Join CUGA</a>
+        <a href="docs/financial-governance.html" class="nav-link">Financial Governance</a>
+        <a href="privacy-policy.html" class="nav-link active">Privacy Policy</a>
+        <a href="terms-of-use.html" class="nav-link">Terms of Use</a>
+    </nav>
+
+    <!-- Language Toggle Buttons (Retained) -->
+    <div class="text-center py-4 bg-gray-200"> <!-- Tailwind bg-gray-200 for button bar -->
         <button class="lang-button px-4 py-2 mr-2 rounded bg-blue-500 text-white" data-lang="fr">Français</button>
         <button class="lang-button px-4 py-2 rounded bg-gray-400 text-gray-800" data-lang="en">English</button>
     </div>
 
-    <div class="lang-fr px-4 py-8">
+    <div class="lang-fr container py-8"> <!-- Added .container for centering and padding -->
         <h1 class="text-3xl font-bold mb-4">Politique de Confidentialité</h1>
         <p class="mb-4">Votre confidentialité est importante pour nous. Cette politique explique comment nous collectons, utilisons et protégeons vos informations personnelles.</p>
         <h2 class="text-2xl font-semibold mb-2">Informations collectées</h2>
@@ -31,7 +54,7 @@
         <p class="mb-4">Nous ne partageons pas vos informations personnelles avec des tiers, sauf si requis par la loi.</p>
     </div>
 
-    <div class="lang-en px-4 py-8">
+    <div class="lang-en container py-8"> <!-- Added .container for centering and padding -->
         <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>
         <p class="mb-4">Your privacy is important to us. This policy explains how we collect, use, and protect your personal information.</p>
         <h2 class="text-2xl font-semibold mb-2">Information Collected</h2>
@@ -42,15 +65,77 @@
         <p class="mb-4">We do not share your personal information with third parties unless required by law.</p>
     </div>
 
+    <footer class="site-footer-bar">
+        <div class="footer-copyright">
+            Copyright &copy;<span id="currentYearPP"></span> CUGA.CA
+        </div>
+        <div class="footer-links">
+            <a href="terms-of-use.html">Terms & Conditions</a>
+            <a href="privacy-policy.html">Privacy Policy</a>
+        </div>
+    </footer>
+
     <script>
+        // Hamburger Menu for Privacy Policy Page
+        const hamburgerTogglePP = document.getElementById('hamburgerToggleButtonPP');
+        const navMenuPP = document.getElementById('navMenuPP');
+
+        if (hamburgerTogglePP && navMenuPP) {
+            hamburgerTogglePP.addEventListener('click', () => {
+                const isOpen = navMenuPP.classList.toggle('is-open');
+                hamburgerTogglePP.setAttribute('aria-expanded', isOpen);
+                navMenuPP.setAttribute('aria-hidden', !isOpen);
+            });
+            // Close menu with Escape key
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && navMenuPP.classList.contains('is-open')) {
+                    navMenuPP.classList.remove('is-open');
+                    hamburgerTogglePP.setAttribute('aria-expanded', 'false');
+                    navMenuPP.setAttribute('aria-hidden', 'true');
+                    hamburgerTogglePP.focus();
+                }
+            });
+            // Close menu when a nav link is clicked
+            navMenuPP.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', () => {
+                    if (navMenuPP.classList.contains('is-open')) {
+                        navMenuPP.classList.remove('is-open');
+                        hamburgerTogglePP.setAttribute('aria-expanded', 'false');
+                        navMenuPP.setAttribute('aria-hidden', 'true');
+                        hamburgerTogglePP.focus();
+                    }
+                });
+            });
+        }
+
+        // Dynamic year in footer
+        const currentYearSpanPP = document.getElementById("currentYearPP");
+        if (currentYearSpanPP) {
+            currentYearSpanPP.textContent = new Date().getFullYear();
+        }
+
+        // Language Switching Logic
         document.addEventListener('DOMContentLoaded', () => {
             const langButtons = document.querySelectorAll('.lang-button');
             const langSections = document.querySelectorAll('.lang-fr, .lang-en');
+            const globalLogoPP = document.getElementById('globalCugaLogoPP');
+
+            const siteLogos = {
+                fr: "assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png",
+                en: "assets/logos/CUGA/Horizontal/EN/Reversed/CUGA-logo-h-en-reverse-rgb-sm.png"
+            };
 
             const setLanguage = (lang) => {
-                langSections.forEach(section => {
-                    section.style.display = section.classList.contains(`lang-${lang}`) ? 'block' : 'none';
-                });
+                // Toggle content display
+                document.querySelectorAll('.lang-fr').forEach(el => el.style.display = lang === 'fr' ? 'block' : 'none');
+                document.querySelectorAll('.lang-en').forEach(el => el.style.display = lang === 'en' ? 'block' : 'none');
+
+                // Update global logo
+                if (globalLogoPP) {
+                    globalLogoPP.src = siteLogos[lang];
+                }
+
+                // Update button styles
                 langButtons.forEach(button => {
                     button.classList.toggle('bg-blue-500', button.dataset.lang === lang);
                     button.classList.toggle('text-white', button.dataset.lang === lang);
@@ -58,6 +143,7 @@
                     button.classList.toggle('text-gray-800', button.dataset.lang !== lang);
                 });
                 document.documentElement.lang = lang;
+                // localStorage.setItem('language', lang); // Optional: if you want to persist lang choice across sessions for this page
             };
 
             langButtons.forEach(button => {

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -3,24 +3,47 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Conditions d'Utilisation | Terms of Use</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <title>Conditions d'Utilisation | Terms of Use - CUGA</title>
+    <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.tailwindcss.com"></script> <!-- Retain Tailwind for now -->
     <style>
-        body {
-            font-family: 'Inter', sans-serif;
-        }
+        /* body { font-family: 'Inter', sans-serif; } */ /* Replaced by Kumbh Sans */
         .lang-en {
             display: none;
         }
     </style>
 </head>
-<body class="bg-gray-100 text-gray-800">
-    <div class="text-center py-4 bg-gray-200">
+<body> <!-- Removed Tailwind bg-gray-100, text-gray-800 -->
+    <!-- Standard CUGA Site Header -->
+    <header class="site-header">
+        <a href="index.html" class="site-logo-link">
+            <img id="globalCugaLogoToU" src="assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png" alt="CUGA Logo" class="site-logo">
+        </a>
+        <button class="hamburger-icon-button" id="hamburgerToggleButtonToU" aria-label="Open menu" aria-expanded="false" aria-controls="navMenuToU">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+    </header>
+
+    <!-- Full-screen Navigation Menu -->
+    <nav class="nav-menu" id="navMenuToU" aria-hidden="true">
+        <a href="index.html" class="nav-link">Home</a>
+        <a href="cuga.html" class="nav-link">Clubs</a>
+        <a href="join.html" class="nav-link">Join CUGA</a>
+        <a href="docs/financial-governance.html" class="nav-link">Financial Governance</a>
+        <a href="privacy-policy.html" class="nav-link">Privacy Policy</a>
+        <a href="terms-of-use.html" class="nav-link active">Terms of Use</a>
+    </nav>
+
+    <!-- Language Toggle Buttons (Retained) -->
+    <div class="text-center py-4 bg-gray-200"> <!-- Tailwind bg-gray-200 for button bar -->
         <button class="lang-button px-4 py-2 mr-2 rounded bg-blue-500 text-white" data-lang="fr">Français</button>
         <button class="lang-button px-4 py-2 rounded bg-gray-400 text-gray-800" data-lang="en">English</button>
     </div>
 
-    <div class="lang-fr px-4 py-8">
+    <div class="lang-fr container py-8"> <!-- Added .container for centering and padding -->
         <h1 class="text-3xl font-bold mb-4">Conditions d'Utilisation</h1>
         <p class="mb-4">En utilisant ce site, vous acceptez les conditions suivantes :</p>
         <h2 class="text-2xl font-semibold mb-2">Utilisation Acceptable</h2>
@@ -31,7 +54,7 @@
         <p class="mb-4">Nous ne sommes pas responsables des dommages résultant de l'utilisation de ce site.</p>
     </div>
 
-    <div class="lang-en px-4 py-8">
+    <div class="lang-en container py-8"> <!-- Added .container for centering and padding -->
         <h1 class="text-3xl font-bold mb-4">Terms of Use</h1>
         <p class="mb-4">By using this site, you agree to the following terms:</p>
         <h2 class="text-2xl font-semibold mb-2">Acceptable Use</h2>
@@ -42,15 +65,77 @@
         <p class="mb-4">We are not responsible for any damages resulting from the use of this site.</p>
     </div>
 
+    <footer class="site-footer-bar">
+        <div class="footer-copyright">
+            Copyright &copy;<span id="currentYearToU"></span> CUGA.CA
+        </div>
+        <div class="footer-links">
+            <a href="terms-of-use.html">Terms & Conditions</a>
+            <a href="privacy-policy.html">Privacy Policy</a>
+        </div>
+    </footer>
+
     <script>
+        // Hamburger Menu for Terms of Use Page
+        const hamburgerToggleToU = document.getElementById('hamburgerToggleButtonToU');
+        const navMenuToU = document.getElementById('navMenuToU');
+
+        if (hamburgerToggleToU && navMenuToU) {
+            hamburgerToggleToU.addEventListener('click', () => {
+                const isOpen = navMenuToU.classList.toggle('is-open');
+                hamburgerToggleToU.setAttribute('aria-expanded', isOpen);
+                navMenuToU.setAttribute('aria-hidden', !isOpen);
+            });
+            // Close menu with Escape key
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && navMenuToU.classList.contains('is-open')) {
+                    navMenuToU.classList.remove('is-open');
+                    hamburgerToggleToU.setAttribute('aria-expanded', 'false');
+                    navMenuToU.setAttribute('aria-hidden', 'true');
+                    hamburgerToggleToU.focus();
+                }
+            });
+            // Close menu when a nav link is clicked
+            navMenuToU.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', () => {
+                    if (navMenuToU.classList.contains('is-open')) {
+                        navMenuToU.classList.remove('is-open');
+                        hamburgerToggleToU.setAttribute('aria-expanded', 'false');
+                        navMenuToU.setAttribute('aria-hidden', 'true');
+                        hamburgerToggleToU.focus();
+                    }
+                });
+            });
+        }
+
+        // Dynamic year in footer
+        const currentYearSpanToU = document.getElementById("currentYearToU");
+        if (currentYearSpanToU) {
+            currentYearSpanToU.textContent = new Date().getFullYear();
+        }
+
+        // Language Switching Logic
         document.addEventListener('DOMContentLoaded', () => {
             const langButtons = document.querySelectorAll('.lang-button');
             const langSections = document.querySelectorAll('.lang-fr, .lang-en');
+            const globalLogoToU = document.getElementById('globalCugaLogoToU');
+
+            const siteLogos = {
+                fr: "assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png",
+                en: "assets/logos/CUGA/Horizontal/EN/Reversed/CUGA-logo-h-en-reverse-rgb-sm.png"
+            };
 
             const setLanguage = (lang) => {
-                langSections.forEach(section => {
-                    section.style.display = section.classList.contains(`lang-${lang}`) ? 'block' : 'none';
-                });
+                // Toggle content display
+                document.querySelectorAll('.lang-fr').forEach(el => el.style.display = lang === 'fr' ? 'block' : 'none');
+                document.querySelectorAll('.lang-en').forEach(el => el.style.display = lang === 'en' ? 'block' : 'none');
+
+                // Update global logo
+                if (globalLogoToU) {
+                    globalLogoToU.src = siteLogos[lang];
+                }
+
+                // Update button styles
                 langButtons.forEach(button => {
                     button.classList.toggle('bg-blue-500', button.dataset.lang === lang);
                     button.classList.toggle('text-white', button.dataset.lang === lang);
@@ -58,6 +143,7 @@
                     button.classList.toggle('text-gray-800', button.dataset.lang !== lang);
                 });
                 document.documentElement.lang = lang;
+                // localStorage.setItem('language', lang); // Optional
             };
 
             langButtons.forEach(button => {

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,57 @@
+# Styling TODOs & Observations
+
+This document lists items related to the application of `styles.css` that require further attention, decisions, or were out of scope for the initial pass.
+
+## General Observations
+
+*   **Hybrid Styling Approach:** Several pages (`index.html`, `cuga.html`, `docs/financial-governance.html`, `join.html`, `waiver.html`) now use a hybrid approach, with `styles.css` for global elements (header, footer) and Tailwind CSS (plus some local `<style>` blocks) for the main content. This was done to preserve complex existing layouts and JavaScript interactions. A future task could be to progressively refactor these main content areas to use the global style system if desired, or to formalize the hybrid approach.
+*   **Font Consistency:** "Kumbh Sans" has been set as the primary font via `styles.css`. Pages that heavily use Tailwind might still have "Inter" or other Tailwind default fonts in their main content areas. Review for full font consistency if required.
+*   **Tailwind Conflicts:** There's a potential for conflicts between `styles.css` and Tailwind CSS. While efforts were made to apply `styles.css` to distinct global areas, a thorough review of style overrides might be needed, especially on hybrid pages. For example, `index.html` had a `bg-blue-700` on the body which was removed as `styles.css` sets a default body background.
+
+## Page-Specific TODOs
+
+### `index.html`
+*   **Page Subtitle/Tagline:** The main page subtitle and tagline (below the global CUGA header) are currently styled with inline styles and old Tailwind classes. These should ideally be refactored to use classes from `styles.css` or have dedicated classes added to `styles.css`.
+*   **Side Navigation:** The floating side navigation (for in-page scrolling) is functional but uses Tailwind. Its styling could be integrated into `styles.css`. The FR/EN versions are duplicated in the HTML; this could be refactored to a single nav updated by JS.
+*   **Button Styling:** Buttons within the main content (e.g., "Voir la liste des clubs CUGA", video tab buttons) use Tailwind. Consider migrating them to `.btn` classes from `styles.css` for consistency.
+*   **Main Content Sections:** All main content sections (sports disciplines, nationals, about us, executive, contact) use Tailwind extensively.
+*   **Footer Version Info:** The `version.json` script appends version info. Its styling is basic. This could be formalized in `styles.css`.
+
+### `cuga.html` (Club Listings)
+*   **Header Subtitle/Tagline:** Similar to `index.html`, the subtitle/tagline below the main logo needs proper styling via `styles.css`.
+*   **Language Buttons:** The language toggle buttons are styled with Tailwind.
+*   **Experimental Banner:** Styled with Tailwind.
+*   **Filter Controls & Club Table:** The entire main content (filters, club listings table) is heavily reliant on Tailwind and JavaScript for its dynamic nature. Untouched by `styles.css`.
+*   **Icon Links in Table:** Links for email, website, Facebook, etc., in the clubs table use FontAwesome icons and Tailwind.
+*   **No Hamburger Menu:** This page doesn't have the global hamburger menu implemented in its header, as its primary navigation is the FR/EN language buttons and the content is very specific. Consider if global nav is needed here.
+
+### `docs/financial-governance.html`
+*   **Secondary Navigation Bar:** The sticky bar containing in-page navigation links and the language selector uses Tailwind and inline styles. This could be componentized in `styles.css`.
+*   **Page Title in Secondary Nav:** The "Nonprofit Governance Guide" title in the secondary nav uses `text-primary-color` (from `styles.css` variables) but other styling is Tailwind.
+*   **Main Content:** The entire interactive guide (introduction, access rights chart, legal framework accordions, restrictions cards, risks section, best practices checklist) uses Tailwind, custom CSS in `<style>`, and JavaScript.
+*   **Font:** The page uses 'Inter' via its own `<style>` block, which is different from the global 'Kumbh Sans'. This should be reconciled. The Kumbh Sans link was added, but Inter is still declared in the local style block.
+
+### `join.html`
+*   **Page Subtitle:** The "Adhésion à CUGA / CUGA Membership" subtitle below the global header needs proper styling (currently `text-xl md:text-2xl font-bold`).
+*   **Main Content Form:** The membership form is styled with Tailwind. Consider if form elements should adopt styles from `styles.css` (`.form-control`, `.form-label`, `.btn`).
+*   **Button "Apply for Membership / Sign Waiver":** Uses Tailwind.
+
+### `waiver.html`
+*   **Page Subtitle:** "Décharge d'adhésion CUGA / CUGA Membership Waiver" subtitle needs styling.
+*   **Main Content Form:** The waiver form is complex and styled with Tailwind. Similar to `join.html`, consider standardizing form elements with `styles.css`.
+*   **Signature Pad:** Styling for the signature pad and related buttons is custom/Tailwind.
+*   **Google Pay Button:** Custom/Tailwind styled.
+*   **Modal/Success Message:** The submission result message uses Tailwind.
+
+### `privacy-policy.html` & `terms-of-use.html`
+*   **Content Styling:** These pages are simpler and now use `.container`. Headings (h1, h2) and paragraphs (p) should largely pick up global styles. A review to ensure all Tailwind utility classes for typography, color, and spacing have been appropriately replaced by global styles in the content areas would be good.
+*   **Language Buttons:** Styled with Tailwind.
+
+## General Next Steps / To Discuss
+*   **Review Hybrid Pages:** Decide on a long-term strategy for pages using both `styles.css` and Tailwind.
+*   **Component Prioritization:** Which common elements (beyond header/footer) should be prioritized for global styling next? (e.g., buttons, form elements, cards).
+*   **JavaScript for Language Switching:** The JS for language switching has been adapted for global elements on each relevant page. This leads to some duplication of logic (e.g., `siteContent` objects, `setLanguage` structure). Consider refactoring into a shared JS module if possible, though page-specific element IDs might make this complex.
+*   **Testing:** Thoroughly test all pages across different screen sizes and browsers to ensure layout and functionality are as expected after these changes. Pay special attention to the hybrid pages.
+*   **Accessibility:** Review color contrast and focus states, especially for elements where Tailwind styling was retained or where new global styles were applied.
+*   **AGENTS.md:** Ensure all changes comply with any instructions in `AGENTS.md` files if they exist in the repository (none were explicitly mentioned for this task).
+*   **Favicon and Manifest:** The `site.webmanifest` and various favicon files (`favicon.ico`, `apple-touch-icon.png`, etc.) are present. Ensure they are correctly linked in the head of all HTML pages if not already. This was not part of the current task but is a general best practice. (Added `styles.css` link, but not these).

--- a/waiver.html
+++ b/waiver.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Demande d'adhésion et décharge CUGA / CUGA Membership Application and Waiver</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.tailwindcss.com"></script> <!-- Retain Tailwind -->
     <link rel="stylesheet" href="assets/fontawesome/css/font-awesome.min.css">
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/signature_pad@4.1.7/dist/signature_pad.umd.min.js"></script>
@@ -19,14 +21,36 @@
     <meta name="description" content="Formulaire de demande d'adhésion et de décharge CUGA. CUGA Membership Application and Waiver Form.">
     <meta name="keywords" content="CUGA, waiver, décharge, membership, adhésion, application, demande, underwater sports, sports subaquatiques, Canada, Canadian Underwater Games Association">
     <style>
-        body { font-family: 'Inter', sans-serif; }
+        /* body { font-family: 'Inter', sans-serif; } */ /* Replaced by Kumbh Sans */
         .lang-en, .lang-fr-inline { display: none; } /* Hide English by default, and French inline for JS control */
         .hidden { display: none; }
     </style>
 </head>
-<body class="bg-blue-700 text-white">
+<body class="text-white"> <!-- Removed bg-blue-700. styles.css will provide body bg -->
+    <!-- Standard CUGA Site Header -->
+    <header class="site-header">
+        <a href="index.html" class="site-logo-link">
+            <img id="globalCugaLogoWaiver" src="assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png" alt="CUGA Logo" class="site-logo"> <!-- Default to FR -->
+        </a>
+        <button class="hamburger-icon-button" id="hamburgerToggleButtonWaiver" aria-label="Open menu" aria-expanded="false" aria-controls="navMenuWaiver">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+    </header>
 
-    <div class="text-center py-4 bg-gray-200">
+    <!-- Full-screen Navigation Menu -->
+    <nav class="nav-menu" id="navMenuWaiver" aria-hidden="true">
+        <a href="index.html" class="nav-link">Home</a>
+        <a href="cuga.html" class="nav-link">Clubs</a>
+        <a href="join.html" class="nav-link">Join CUGA</a>
+        <a href="waiver.html" class="nav-link active">Waiver/Application</a>
+        <a href="docs/financial-governance.html" class="nav-link">Financial Governance</a>
+        <!-- Links for terms, privacy will be in footer -->
+    </nav>
+
+    <!-- Language Toggle Buttons and Test Data Button (Retained) -->
+    <div class="text-center py-4 bg-gray-200"> <!-- Tailwind bg-gray-200 for button bar -->
         <button class="lang-button px-4 py-2 mr-2 rounded bg-blue-500 text-white" data-lang="fr">
             <i class="fa fa-fleur-de-lis"></i> Français
         </button>
@@ -38,20 +62,18 @@
         </button>
     </div>
 
+    <!-- Experimental Banner (Retained) -->
     <div class="text-center py-3 bg-yellow-300 text-black text-sm">
         This is an experimental website for CUGA. The official CUGA website can be found at <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-700">https://cuga.org/</a>.
         <br>
         Ceci est un site web expérimental pour CUGA. Le site officiel de CUGA se trouve à <a href="https://cuga.org/" target="_blank" rel="noopener noreferrer" class="underline font-semibold hover:text-blue-700">https://cuga.org/</a>.
     </div>
 
-    <header class="bg-[#386DC0] text-white py-8 text-center shadow-lg">
-        <img src="assets/logos/CUGA/Horizontal/EN/FullColor/CUGA-logo-h-en-fullColor-rgb.svg" alt="CUGA Logo" class="h-12 mx-auto">
-        <p class="mt-1 text-md md:text-lg italic">
-            <span class="lang-fr">Décharge d'adhésion CUGA</span>
-            <span class="lang-en">CUGA Membership Waiver</span>
-        </p>
-    </header>
-
+    <!-- Page specific title/subtitle, to be shown/hidden by JS lang toggle -->
+    <div id="pageSubtitleContainerWaiver" class="text-center py-4" style="background-color: var(--primary-color); color: var(--white);">
+        <p id="waiverPageSubtitle" class="text-xl md:text-2xl font-bold"></p>
+    </div>
+    <!-- Old header was here, removed by previous step -->
     <main class="container mx-auto px-4 py-16">
         <div class="bg-white text-gray-800 rounded-xl shadow-xl p-8 md:p-12">
             <h1 class="text-3xl md:text-4xl font-bold text-center mb-8 text-blue-800">
@@ -383,20 +405,57 @@
         </div>
     </main>
 
-    <footer class="bg-gray-900 text-gray-400 py-8 text-center">
-        <div class="container mx-auto px-4">
-            <p>&copy; 2025 CUGA. <span class="lang-fr">Tous droits réservés.</span><span class="lang-en">All rights reserved.</span></p>
-            <p class="mt-4">
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline lang-fr">Politique de Confidentialité</a>
-                <a href="privacy-policy.html" class="text-blue-400 hover:underline lang-en">Privacy Policy</a> |
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline lang-fr">Conditions d'Utilisation</a>
-                <a href="terms-of-use.html" class="text-blue-400 hover:underline lang-en">Terms of Use</a>
-            </p>
+    <footer class="site-footer-bar">
+        <div class="footer-copyright">
+            Copyright &copy;<span id="currentYearWaiver"></span> CUGA.CA
+        </div>
+        <div class="footer-links">
+            <a href="terms-of-use.html">Terms & Conditions</a>
+            <a href="privacy-policy.html">Privacy Policy</a>
         </div>
     </footer>
 
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
+        // Hamburger Menu for Waiver Page
+        const hamburgerToggleWaiver = document.getElementById('hamburgerToggleButtonWaiver');
+        const navMenuWaiver = document.getElementById('navMenuWaiver');
+
+        if (hamburgerToggleWaiver && navMenuWaiver) {
+            hamburgerToggleWaiver.addEventListener('click', () => {
+                const isOpen = navMenuWaiver.classList.toggle('is-open');
+                hamburgerToggleWaiver.setAttribute('aria-expanded', isOpen);
+                navMenuWaiver.setAttribute('aria-hidden', !isOpen);
+            });
+            // Close menu with Escape key
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && navMenuWaiver.classList.contains('is-open')) {
+                    navMenuWaiver.classList.remove('is-open');
+                    hamburgerToggleWaiver.setAttribute('aria-expanded', 'false');
+                    navMenuWaiver.setAttribute('aria-hidden', 'true');
+                    hamburgerToggleWaiver.focus();
+                }
+            });
+            // Close menu when a nav link is clicked
+            navMenuWaiver.querySelectorAll('.nav-link').forEach(link => {
+                link.addEventListener('click', () => {
+                    if (navMenuWaiver.classList.contains('is-open')) {
+                        navMenuWaiver.classList.remove('is-open');
+                        hamburgerToggleWaiver.setAttribute('aria-expanded', 'false');
+                        navMenuWaiver.setAttribute('aria-hidden', 'true');
+                        hamburgerToggleWaiver.focus();
+                    }
+                });
+            });
+        }
+
+        // Dynamic year in footer for Waiver Page
+        const currentYearSpanWaiver = document.getElementById("currentYearWaiver");
+        if (currentYearSpanWaiver) {
+            currentYearSpanWaiver.textContent = new Date().getFullYear();
+        }
+
+        // Existing Waiver Page JS + Language Switching Update
         let allClubsWaiver = []; // Holds data from cuga_club_data.json
 
         async function fetchWaiverClubData() {
@@ -601,16 +660,38 @@
 
             const langButtons = document.querySelectorAll('.lang-button');
             const htmlTag = document.documentElement;
+            const globalLogoWaiver = document.getElementById('globalCugaLogoWaiver');
+            const waiverPageSubtitle = document.getElementById('waiverPageSubtitle');
+            // Note: Footer links for this page are simple and don't need dynamic text from JS,
+            // but logo and subtitle do.
+
+            const pageSpecificContentWaiver = {
+                fr: {
+                    logo: "assets/logos/CUGA/Horizontal/FR/Reversed/CUGA-logo-h-fr-reverse-rgb-sm.png",
+                    subtitle: "Décharge d'adhésion CUGA"
+                },
+                en: {
+                    logo: "assets/logos/CUGA/Horizontal/EN/Reversed/CUGA-logo-h-en-reverse-rgb-sm.png",
+                    subtitle: "CUGA Membership Waiver"
+                }
+            };
 
             function updateDisplayedLanguage(lang) {
                 htmlTag.lang = lang;
-                document.querySelectorAll('.lang-fr, .lang-en, .lang-fr-inline, .lang-en-inline').forEach(el => {
-                    if (el.classList.contains(`lang-${lang}`) || el.classList.contains(`lang-${lang}-inline`)) {
-                        el.style.display = el.classList.contains('lang-fr-inline') || el.classList.contains('lang-en-inline') ? 'inline' : 'block';
-                    } else {
-                        el.style.display = 'none';
-                    }
-                });
+
+                // Toggle content display for elements with lang-fr/lang-en classes
+                document.querySelectorAll('.lang-fr, .lang-fr-inline').forEach(el =>
+                    el.style.display = (lang === 'fr') ? (el.classList.contains('lang-fr-inline') ? 'inline' : 'block') : 'none'
+                );
+                document.querySelectorAll('.lang-en, .lang-en-inline').forEach(el =>
+                    el.style.display = (lang === 'en') ? (el.classList.contains('lang-en-inline') ? 'inline' : 'block') : 'none'
+                );
+
+                // Update global header logo and page subtitle
+                if (globalLogoWaiver) globalLogoWaiver.src = pageSpecificContentWaiver[lang].logo;
+                if (waiverPageSubtitle) waiverPageSubtitle.textContent = pageSpecificContentWaiver[lang].subtitle;
+
+                // Update language toggle buttons styling
                 langButtons.forEach(button => {
                     button.classList.toggle('bg-blue-600', button.dataset.lang === lang);
                     button.classList.toggle('text-white', button.dataset.lang === lang);
@@ -618,6 +699,7 @@
                     button.classList.toggle('text-gray-800', button.dataset.lang !== lang);
                 });
 
+                // Update placeholders for inputs
                 const digitalSignatureInput = document.getElementById('digitalSignature');
                 if (digitalSignatureInput) {
                     digitalSignatureInput.placeholder = lang === 'fr' ? digitalSignatureInput.getAttribute('placeholder-lang-fr') : digitalSignatureInput.getAttribute('placeholder-lang-en');


### PR DESCRIPTION
- Linked styles.css and Kumbh Sans font to all relevant HTML pages.
- Replaced local headers and footers with a standardized global header (site-header) and footer (site-footer-bar) from styles.css.
- Updated JavaScript on pages with language toggles (index.html, cuga.html, join.html, waiver.html, privacy-policy.html, terms-of-use.html) to manage language-specific content in the new global headers/footers (e.g., logo paths, subtitles, dynamic links) and for page-specific elements.
- Added JavaScript for hamburger menu functionality and dynamic copyright year in the footer to all styled pages.
- Applied .container class to content sections on simpler pages (privacy-policy.html, terms-of-use.html) for consistent padding and width.
- Maintained Tailwind CSS for complex content sections on pages like index.html, cuga.html, docs/financial-governance.html, join.html, and waiver.html to preserve existing layouts and interactivity (hybrid approach).
- Intentionally skipped styling for simulator.html as it's a self-contained application.
- Created todo.md detailing styling inconsistencies, items not covered by the global CSS, potential Tailwind conflicts, and suggestions for future improvements.