### PR TITLE
Add experimental site warning banner to all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,10 @@
     <!-- All custom styles moved to styles.css. See styles.html for design system examples. -->
 </head>
 <body>
-
+<div id="experimental-site-banner" style="background-color: #fff3cd; color: #856404; padding: 10px; text-align: center; font-weight: bold; border-bottom: 1px solid #ffeeba;">
+    <span class="lang-fr">⚠️ Ceci est un site expérimental/test de la CUGA. Pour le site officiel, visitez <a href="https://cuga.org" target="_blank" style="color: #856404; text-decoration: underline;">cuga.org</a></span>
+    <span class="lang-en" style="display: none;">⚠️ This is an experimental/test site for CUGA. For the official site, visit <a href="https://cuga.org" target="_blank" style="color: #856404; text-decoration: underline;">cuga.org</a></span>
+</div>
     <div class="page-wrapper">
         <header id="top-bar-placeholder" class="site-header top-bar">
             <div class="site-header-content">

--- a/shared/header.html
+++ b/shared/header.html
@@ -1,3 +1,7 @@
+<div id="experimental-site-banner" style="background-color: #fff3cd; color: #856404; padding: 10px; text-align: center; font-weight: bold; border-bottom: 1px solid #ffeeba;">
+    <span class="lang-fr">⚠️ Ceci est un site expérimental/test de la CUGA. Pour le site officiel, visitez <a href="https://cuga.org" target="_blank" style="color: #856404; text-decoration: underline;">cuga.org</a></span>
+    <span class="lang-en" style="display: none;">⚠️ This is an experimental/test site for CUGA. For the official site, visit <a href="https://cuga.org" target="_blank" style="color: #856404; text-decoration: underline;">cuga.org</a></span>
+</div>
 <header class="site-header">
     <div class="container site-header-content">
         <a href="index.html" class="site-logo-link">


### PR DESCRIPTION
This banner informs users that the site is a test/experimental version and links to the official cuga.org website.

The banner includes both French and English text and integrates with the existing language switching functionality.

Changes made:
- Added banner HTML to shared/header.html to appear on most pages.
- Added banner HTML directly to index.html as it uses a custom header implementation.
- Ensured banner text visibility is controlled by the lang-fr/lang-en class system.