### PR TITLE
Fix: Implement sticky footer using flexbox

### DIFF
--- a/cuga.html
+++ b/cuga.html
@@ -91,13 +91,15 @@
         <p id="cugaTagline" class="mt-1 text-md md:text-lg italic">Plongez dans l'action avec le Hockey et le Rugby Subaquatique !</p>
     </header>
 
-    <div id="filter-controls" class="w-full px-4 py-8 bg-gray-100 text-gray-800 rounded-lg shadow-md">
-        <!-- Filter controls will be added here -->
-    </div>
+    <main>
+        <div id="filter-controls" class="w-full px-4 py-8 bg-gray-100 text-gray-800 rounded-lg shadow-md">
+            <!-- Filter controls will be added here -->
+        </div>
 
-    <div id="clubs-container" class="w-full px-4 py-8 overflow-x-auto text-gray-800">
-        <!-- Club listings will be displayed here -->
-    </div>
+        <div id="clubs-container" class="w-full px-4 py-8 overflow-x-auto text-gray-800">
+            <!-- Club listings will be displayed here -->
+        </div>
+    </main>
 
     <footer id="footer-fr" class="bg-gray-900 text-gray-400 py-8 text-center">
         <div class="container mx-auto px-4">

--- a/index.html
+++ b/index.html
@@ -129,6 +129,8 @@
         </div>
     </div>
 
+    <div id="footer-placeholder"></div>
+
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script src="js/main.js"></script>
     <script src="js/menu.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -92,6 +92,18 @@ body {
   box-sizing: border-box;
 }
 
+/* Sticky Footer Implementation */
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+main { /* Assuming <main> is the primary content wrapper */
+  flex-grow: 1;
+}
+/* End Sticky Footer Implementation */
+
 /* Site Header */
 .site-header {
   background-color: var(--primary-color);
@@ -462,8 +474,11 @@ body {
 }
 
 /* General page wrapper to help with sticky footer if needed */
-/* body is already display:flex, flex-direction:column, min-height:100vh */
-/* .page-wrapper is display:flex, flex-direction:column, flex-grow:1 */
+.page-wrapper { /* Used in index.html */
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
 /* This setup should make footer (if any) stick to bottom. */
 
 /* Ensure .site-header doesn't get Tailwind background if Tailwind is removed later */


### PR DESCRIPTION
- Modified styles.css to apply flexbox properties to body, main, and .page-wrapper to ensure the footer sticks to the bottom of the viewport, regardless of content height.
- Updated index.html to include the #footer-placeholder and ensure its .page-wrapper cooperates with the flexbox structure.
- Updated cuga.html by wrapping its main content in a <main> tag to work with the sticky footer CSS.
- Verified that other pages like about.html and contact.html have a compatible structure.